### PR TITLE
fix(parsers): border type value in lowercase for css parser

### DIFF
--- a/parsers/to-css-custom-properties/tokens/border.ts
+++ b/parsers/to-css-custom-properties/tokens/border.ts
@@ -9,6 +9,6 @@ export class Border extends BorderToken {
     const { color, type, width } = this.value;
     const { measure, unit } = width.value;
     const { r, g, b, a } = color.value;
-    return `${measure}${unit} ${type} rgba(${r}, ${g}, ${b}, ${a})`;
+    return `${measure}${unit} ${type.toLowerCase()} rgba(${r}, ${g}, ${b}, ${a})`;
   }
 }


### PR DESCRIPTION
## What it does

Value for border type was given in lowercase by Specify API (like in Figma API i suppose), but by convention it should be in lowercase.

## Additionnal informations

StyleLint with default config will throw an error ([see exemple here](https://stylelint.io/demo#N4Igxg9gJgpiBcIBGEBOtXwAQHYAOAHlgMoDyAMgJIAiWqA5kgIYAUAjAJwcA0WALAA5eAZhy8ADADoOwgJQBuENxABnAJ4A7AC5MCCcCpVLwEDQDMAlvX3AAOhqxZbIVAFcANjBXPsdh46cQJi0AWjdPEI0IENcNAGsogHcNHywtNxhuewDApHcIMDjI6JgAWzwtNVT010zsgOdIfNRikIsNADcmdwsoEIALGAJqjKz-R0aIUtKYbVayiqqENNH6iZBYMHcmVGCLUxC8gqKokKhXPB6wYJgQvFQIPBhULQsvVIBtNYCauvGAvw5HLOKxRVAwT7fIGBSAaFQwMCuV4dW7nS4Wa5aLwhRIWLT9M4WMxmZ6zUJddy1bwgKEBAC6tIAvt86WNgRsEdtdq8DkdCq0VP00PimBo+vdHs9KiEICjUKheu9lr82Q0QGZTKEzExShZ3GpWmirjdIjqldgVd9nBq5trdfrWrrDO16CF6LNnhiQna9Qa4jA1Ik0FARrVVeszLEwDyNCFru4wK12hTeqG-uzIxpo-tY-HE6dYio8EwwDA+pLuWg0+HApnswcehoYDs3bsoG85qconCdGKdn12+D6yllat-s5-WozLsZmdOTs9gdThZysLRVpq1aQDN20xvc2tK5wabZwX4kkRxax+zTrAVKWxS6QkWEUSMXillew1vbxdjViQmCNpVxeMIPHNFZv3HEBf3RTFbnhTxozQakv3TNVTgWaUVAgI9S03aDMIIdI93hXUmlMVDIPQ9Zl06bpejOXC8gQ7ZBTjKYZm0KjLWgiUnheA0zwSCBkgI9lEIRLQ0DueFXCgaItiYQxWliESxNHKCJJgJDpJaPA5IUkIdLKMlVPPUTL2omtnEk5CWkqJ5zPUqzeIk9Iny7GBEkbCFNJowJYjxZyL3EtUgPCW4sINXzDhgDVwUhf51m6RImDUaka0cQFoUCIZSwqJLcrVPk4k8FSmDMLEWhUM0T1uUrysy2kMwsVAVFCJsOrLZwWqwVk+pBegwT87AvmSoFnEq6qOOmMleomxwGQm5l-gG6CIvA+q42U0bAnyRJnmcGyglCSLtqLEtbmmo7lim9w0oy58XQiXzjq3TaIjIjEIHyWMmx89prqq27sHux7mug0q43yFQnyQXZS2M8ppVipB4rQPbnCbOV3qh-J+S2CA4Y0V0EauyJvNim7UFScH0sh9loaJkmycR24AbRjHEruoIHoZkJSg8V4QjepQt2Z2H4fZ59iyR9GEqxvmIee0nXqBvGmYJopJQ0aWKc5oHAJB2nedSgWhfcEWxZO6Hdf1pHLqRmm6eVgXWfVptNZK7WZSePXScOGWnYa7mlfNjLvfWCiWkGAgdvhV2Dtuk6Y4GIZRdmeh8VdwVhSjmFOLM6LRaNhXMaKya3cj8WJpy6FnHymBCuWcbiojNqOsp7qQxpRb+qytVQQr1u+vWDq1E8RtQkgaZRSgak+uW6FVpydb2VnrjQkSfo8S8OXbnaOHYFdiPGbVREOqmO4HgE6US65xXK-ZM+C+ywaQCbluxrHwIabjVwV9Sg3wrJUN+VdLDtU6l4LEvcl6D3WMPHmP9+4pRNrNLe4D2RH0VKregnsGrawWsVZeQJV70hOpsLki5YzMEDiHY21VXY4xTluKhC4YyHFFK6Bh5dkF-35jXSh85uQ5kOL7b6FF-pUyNi7M2giVCC2FhYUuXta7snYaI3kEiyg-T+rLCmciwbV0UR7W4Ns2EiJoeI44z5dFSIMfLMOzCYC43UWqTR1joZmNUbcUoug5xKS0XCVIbBhFBK8b7EieonySN+qYU+CiC7OE8ZwhxhsmyMNBgIlWltrYa3cesVJYiHEMKMTk92L1zEFPCdQtJ8TYy8OcbzFhptakcLEQ-MuzSUENxMeA+uVcv4blHqgv+6DikJMKbla0ndoE92IbldeMyQBIL2m3duU10Gb3mtMvpODYB4IITYwoizoSkJyOQpaJ06z1LnpTQGmTyn0yenklRFjoK3JKZxUiB8smm2MWfI51S1E3KjHc-xjjQ5Pxaa41hnzwViP8fHLpXVUjiDBVmThGg6rXETrzZObStxfIOMWcE2hBjwkURkw+cJFSJNyco3xyT1SItJTsMklLsQMIOUrVpwLmXTOtGy2MO895lJNgyhmLL2iwG0DQ1IAAmE6nhSb4hCAAL2eNEM8eIwrrGRcjRYviqJhK3DuCwe4STBCPLcUpfznn9KFduMslr9w2uPPaimfC+VwqJdBC1VqDy2u2nipWhKWWBvdYeY8ZLOVeG5X83lLi3EnSjdamNtxdik1uBWYIMkJVMPkRDSNrqg0eqzdw3NAl801T+T6qVQjzVlpCAAR1qKgGKFgu6bz3DS-5jbFFvMFWmlt7bnhdp7T8qFA7i2VLViCvyo7dxto7ZOme06mkwuMa0llmFfo4l3liEO+rAinCdKzYyYoZRmGfLhVASMaWnuxq4Uo6MWieCYO2QOWqHiDr3a+99rRomNldL+4mz6QD8SlAaMNSdRLwvZOdVF0KR69KrkC4dHzoSDPZMM5+KzIFdy6rAs5QJln7OGmhrAGzipbJmjs7QZG15MhZCdOyelAJaA8kgJEDVEb+i0KYpNdKT6wtTVuDjMlgg8b437Z4taZ2Ot3c6qTLQZMKl4wBPNnGt3Uexn6llanZpIHaIpwt2SXnn3HiZeyJmzO6frT0ipTboLGbvA+KA657M4s412A4J7-Lsds5xnoU77n9sda-VTIWZJhY3fcvT-CDMSbc7FlohqUNUQxZJ9LskYDyUUmxRRcGCUIf9dpXSMkDIFaMkpFScaKUJuExTZN4nENqmMzVwrxlPBbwTuG8rRm8vdaMiZfr6SIA6BjK7BSrgWLDaqw5NQTlSvGIjc6oKM9drwcOhVtUFJaghEnEGdAA3dsdfWId6p4XIWRclXO15TLsMHe6Ed+LGDfmGIe4ChRAqXtXbezdhLkKku+tS+ya7pcu6ZZRl2tFyxxD1FWoyEAjIgA))

## Linear ticket
❌
