### PR TITLE
fix(parsers): remove extra space at beginning of shadow value

### DIFF
--- a/parsers/to-css-custom-properties/to-css-custom-properties.spec.ts
+++ b/parsers/to-css-custom-properties/to-css-custom-properties.spec.ts
@@ -21,7 +21,7 @@ describe('To css', () => {
       const { r, g, b, a } = color.value;
       const innerText = isInner ? 'inset ' : '';
       if (acc === '') {
-        return `${innerText} ${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r}, ${g}, ${b}, ${a})`;
+        return `${innerText}${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r}, ${g}, ${b}, ${a})`;
       }
 
       return `${acc}, ${innerText}${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r}, ${g}, ${b}, ${a})`;
@@ -34,7 +34,7 @@ describe('To css', () => {
           .toString('rgb')}`,
       ),
     ).toBe(true);
-    expect(result.includes(`${libs._.kebabCase(shadow.name)}:${shadowValue}`)).toBe(true);
+    expect(result.includes(`${libs._.kebabCase(shadow.name)}: ${shadowValue}`)).toBe(true);
     expect(
       result.includes(
         `${libs._.kebabCase(measurement.name)}: ${measurement.value.measure}${

--- a/parsers/to-css-custom-properties/tokens/shadow.ts
+++ b/parsers/to-css-custom-properties/tokens/shadow.ts
@@ -12,12 +12,12 @@ export class Shadow extends ShadowToken {
       const y = offsetY.value;
       const bl = blur.value;
       const { r, g, b, a } = color.value;
-      const innerText = isInner ? 'inset' : '';
+      const innerText = isInner ? 'inset ' : '';
       if (acc === '') {
-        return `${innerText} ${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r},${g},${b},${a})`;
+        return `${innerText}${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r},${g},${b},${a})`;
       }
 
-      return `${acc}, ${innerText} ${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r},${g},${b},${a})`;
+      return `${acc}, ${innerText}${x.measure}${x.unit} ${y.measure}${y.unit} ${bl.measure}${bl.unit} rgba(${r},${g},${b},${a})`;
     }, '');
   }
 }


### PR DESCRIPTION
## What it does

It fix shadow values given by `shadow.ts`, actually if shadow is not an inner shadow (most of cases) space between `'inset'` and `${x.measure}` is kept in value as it is hardcoded in template string.

## Additionnal informations

shadow **`value`** output:
> before:
`" 37px 71px 2px rgba(144, 63, 6, 0.28)"` or `"inset 37px 71px 2px rgba(144, 63, 6, 0.28)"`
> after:
`"37px 71px 2px rgba(144, 63, 6, 0.28)"` or `"inset 37px 71px 2px rgba(144, 63, 6, 0.28)"`

## Linear ticket
❌
