### PR TITLE
Add exportDefault option for to-jss parser

### DIFF
--- a/parsers/to-jss/README.md
+++ b/parsers/to-jss/README.md
@@ -45,6 +45,7 @@ interface x {
     }>;
     formatConfig: Partial<{
       jssObjectName: string,
+      exportDefault: boolean,
       endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
       tabWidth: number;
       useTabs: boolean;
@@ -68,6 +69,7 @@ interface x {
     },
     "formatConfig": {
       "jssObjectName": "lightTheme",
+      "exportDefault": false,
       "tabWidth": 4,
       "singleQuote": true,
     }
@@ -115,7 +117,9 @@ const lightTheme = {
   depth: {
     towelsUniformTasty: "8",
   }
-}
+};
+
+export default lightTheme;
 ```
 
 ## Types

--- a/parsers/to-jss/to-jss.parser.ts
+++ b/parsers/to-jss/to-jss.parser.ts
@@ -48,6 +48,7 @@ export type OptionsType =
         tabWidth: number;
         useTabs: boolean;
         singleQuote: boolean;
+        exportDefault: boolean;
       }>;
     }>
   | undefined;
@@ -60,6 +61,7 @@ export default async function (
   try {
     const transformNameFn = _[options?.formatName || 'camelCase'];
     const objectName = options?.formatConfig?.jssObjectName || 'theme';
+    const isExported = options?.formatConfig?.exportDefault ?? true;
 
     const tokensGroupByType = _.groupBy(tokens, 'type');
     const styles = Object.keys(tokensGroupByType).reduce((result, type) => {
@@ -86,7 +88,7 @@ export default async function (
       return result;
     }, '');
 
-    return prettier.format(`const ${objectName} = {${styles}}`, {
+    return prettier.format(`const ${objectName} = {${styles}} ${isExported ? `;\n\nexport default ${objectName};` : ';'}`, {
       ...options?.formatConfig,
       parser: 'babel',
     });


### PR DESCRIPTION
## What it does

It add exportDefault option for to-jss parser
default value: `true`

result as
``` js
const ${jssObjectName} = {
  ...
};

export default ${jssObjectName};
```

## Additionnal informations

// If the linear ticket needed dev on others projects, put the PRs link here

## Linear ticket
❌
