### PR TITLE
feat(to-jss): Added commonjs support and 'export only' as well

### DIFF
--- a/parsers/to-jss/to-jss.spec.ts
+++ b/parsers/to-jss/to-jss.spec.ts
@@ -204,4 +204,60 @@ describe('To jss', () => {
 
     done();
   });
+
+  it('Module Format - es6 - export default ', async () => {
+    const jssObjectName = 'moduleTheme';
+
+    const options: OptionsType = {
+      formatConfig: { exportDefault: true, jssObjectName },
+    };
+
+    const result = await toJss(seeds.tokens as Array<Token>, options, libs);
+
+    expect(result.includes(`export default ${jssObjectName}`)).toBeTruthy();
+    expect(result.includes(`export const ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes('module.exports')).toBeFalsy();
+  });
+
+  it('Module Format - es6 - export default ', async () => {
+    const jssObjectName = 'moduleTheme';
+
+    const options: OptionsType = {
+      formatConfig: { exportDefault: false, jssObjectName },
+    };
+
+    const result = await toJss(seeds.tokens as Array<Token>, options, libs);
+
+    expect(result.includes(`export default ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes(`export const ${jssObjectName}`)).toBeTruthy();
+    expect(result.includes('module.exports')).toBeFalsy();
+  });
+
+  it('Module Format - commonjs - export default ', async () => {
+    const jssObjectName = 'moduleTheme';
+
+    const options: OptionsType = {
+      formatConfig: { module: 'commonjs', exportDefault: true, jssObjectName },
+    };
+
+    const result = await toJss(seeds.tokens as Array<Token>, options, libs);
+
+    expect(result.includes(`export default ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes(`export const ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes(`module.exports = ${jssObjectName}`)).toBeTruthy();
+  });
+
+  it('Module Format - commonjs - export default ', async () => {
+    const jssObjectName = 'moduleTheme';
+
+    const options: OptionsType = {
+      formatConfig: { module: 'commonjs', exportDefault: false, jssObjectName },
+    };
+
+    const result = await toJss(seeds.tokens as Array<Token>, options, libs);
+
+    expect(result.includes(`export default ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes(`export const ${jssObjectName}`)).toBeFalsy();
+    expect(result.includes(`module.exports = { ${jssObjectName} }`)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Hello ! 

I have made some modifications to the `to-jss` parser to improve the output possibilities in terms of module support:

- CommonJs support (`module.exports = themeName` & `module.exports = { themeName }`)
- When `exportDefault` is set to `false` it makes an `exports const` rather than not exporting. Imho, a generated file without an export will be painful to use because each time we update it, we'll have to add an export manually
- Made test as well (tell me if the naming is not the right one)
