### PR TITLE
fix(text-styles): fix text styles typing for parsers

### DIFF
--- a/types/tokens/TextStyle.ts
+++ b/types/tokens/TextStyle.ts
@@ -65,7 +65,8 @@ export type VerticalAlignValue =
   | 'text-bottom'
   | 'middle'
   | 'top'
-  | 'bottom';
+  | 'bottom'
+  | 'center';
 
 export interface TextStyleValue {
   color?: {


### PR DESCRIPTION
## What it does

Fix text styles typing for parsers
Vertical text align should allow value `center`