### PR TITLE
feat: add vector/bitmap name format options + letterSpacing

### DIFF
--- a/parsers/to-jss/README.md
+++ b/parsers/to-jss/README.md
@@ -23,7 +23,7 @@ primaryBorder: {
 ```
 
 ### Optionnal format for font
-By passing `"classObject"` to `textStyleFormat` the parser will generate a jss class object containing the `color` property (which isn't a `font` sub-property value).
+By passing `"classObject"` to `textStyleFormat` the parser will generate a jss class object containing the `color` and `letter-spacing` properties (which aren't `font`'s sub-properties).
 
 ## Interface
 ```ts
@@ -44,12 +44,15 @@ interface x {
       fontSizeUnit: 'px' | 'pt';
     }>;
     formatConfig: Partial<{
-      jssObjectName: string,
-      exportDefault: boolean,
+      jssObjectName: string;
+      exportDefault: boolean;
       endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
       tabWidth: number;
       useTabs: boolean;
       singleQuote: boolean;
+      isVectorFileType: boolean;
+      isBitmapFileType: boolean;
+      isBitmapScale: boolean;
     }>;
   }>
 }

--- a/parsers/to-jss/tokens/textStyle.ts
+++ b/parsers/to-jss/tokens/textStyle.ts
@@ -8,10 +8,13 @@ export class TextStyle extends TextStyleToken {
   }
 
   toJss({ textStyleFormat = 'classObject', colorFormat = 'hex' }: FormatTokenType) {
-    const { font, color: c, fontSize: fs, lineHeight: lh } = this.value;
+    const { font, color: c, fontSize: fs, lineHeight: lh, letterSpacing: ls } = this.value;
     const { fontPostScriptName, fontWeight } = font.value;
     const color = c?.value;
     const { measure: fontSize, unit: fsUnit } = fs.value;
+    const { measure: letterSpacing } = ls?.value
+      ? ls.value
+      : { measure: 'normal' };
     const { measure: lineHeight, unit: lhUnit } = lh?.value
       ? lh.value
       : { measure: 'normal', unit: 'px' };
@@ -28,6 +31,7 @@ export class TextStyle extends TextStyleToken {
       classObject: JSON.stringify({
         color: tinycolor(color).toString(colorFormat),
         font: fontObject,
+        letterSpacing: letterSpacing,
       }),
       array: JSON.stringify([
         fontWeight,


### PR DESCRIPTION
## What it does
It add following features to `to-jss` parser:
- `letterSpacing` property is added text style tokens when `classObject` format is passed to `textStyleFormat`
- `isVectorFileType` and `isBitmapFileType` added to `formatConfig` options to remove filetype in token names
- `isBitmapScale` added to `formatConfig` options to remove  all scale stuff like `@2x` from the bitmap token names

## Additionnal informations
`isVectorFileType`, `isBitmapFileType` and `isBitmapScale` are all setted to `true` by default.

tested all options on `@station/NewThemeLight` repo with json provided by Specify API (mostly to test `letterSpacing` and scale/filetype in DT names which are not included in sample file used by tests)

[ds.json.zip](https://github.com/Specifyapp/parsers/files/6045611/ds.json.zip)


## Linear ticket
Resolves nothing 
