### PR TITLE
fix(font): fix font dl without parser

### DIFF
--- a/types/tokens/Font.ts
+++ b/types/tokens/Font.ts
@@ -12,6 +12,7 @@ export interface FontValue {
   isItalic?: boolean;
   provider?: 'Custom font' | 'Google Fonts';
   url?: string;
+  format?: string;
 }
 
 export class FontToken extends Token implements TokenInterface {


### PR DESCRIPTION
## What it does

Fix the typing of the Font Token Value (changed due to the fix that allows to dl the font file from the CLI without using any parsers)
