### PR TITLE
Fix typos

### DIFF
--- a/parsers/camelcasify/README.md
+++ b/parsers/camelcasify/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and apply camelcase function on the given keys.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 

--- a/parsers/convert-font/README.md
+++ b/parsers/convert-font/README.md
@@ -4,7 +4,7 @@
 
 Convert font in several formats.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 

--- a/parsers/filter/README.md
+++ b/parsers/filter/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-filters the tokens by their name using a provided regular expression.
+Filters the tokens by their name using a provided regular expression.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 
@@ -27,14 +27,14 @@ interface parser {
 
 | Parameter       | Required | Type              | Default | Description                                                                                                                                                                                                                                            |
 | --------------- | -------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `key`           | required | `string`          |         | key path to apply the filter function                                                                                                                                                                                                                  |
-| `regex`         | required | `object` `string` |         | if string: the parameter used for the [constructor of the regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor). If your use case need to use flags prefer object notation. |
-| `regex.pattern` | required | `string`          |         | the pattern of the regex used as first argument of the [constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor)                                                         |
-| `regex.flags`   | optional | `string`          |         | the flags to use for regex. In the regex constructor it's the second argument [constructor of the regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor)                     |
+| `key`           | required | `string`          |         | Key path to apply the filter function.                                                                                                                                                                                                                  |
+| `regex`         | required | `object` `string` |         | If you need to define flags inside the [constructor of the regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor), use the `object` notation. Otherwise use the `string` notation. |
+| `regex.pattern` | required | `string`          |         | The pattern of the regex used as first argument of the [constructor of the regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor).                                                         |
+| `regex.flags`   | optional | `string`          |         | The flags to use for regex. In the regex constructor it's the second argument [constructor of the regex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#literal_notation_and_constructor).                     |
 
 ### Good to know
 
-Under the hood the regex is build like:
+Under the hood the regex is built as:
 
 `let re = new RegExp('ab+c', 'i') // constructor with string pattern as first argument`
 
@@ -73,7 +73,7 @@ Array<Record<string, any>>
 }
 ```
 
-With this config, we will filter the elements containing the word Background
+With this config, we will filter the elements containing the word "Background".
 
 ### Before/After
 

--- a/parsers/kebabcasify/README.md
+++ b/parsers/kebabcasify/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and apply kebabcase function on the given keys.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 

--- a/parsers/omit/README.md
+++ b/parsers/omit/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-Loop on all tokens and get only keys given in params.
+Loop on all tokens and only get keys not given in parameters.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 ```ts

--- a/parsers/pascalcasify/README.md
+++ b/parsers/pascalcasify/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and apply pascalcase function on the given keys.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 ## Interface
 
 ```ts

--- a/parsers/pick/README.md
+++ b/parsers/pick/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and get only keys given in params.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 ```ts

--- a/parsers/px-to-rem/README.md
+++ b/parsers/px-to-rem/README.md
@@ -3,7 +3,7 @@
 
 Convert pixel measurement to rem.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 

--- a/parsers/snakecasify/README.md
+++ b/parsers/snakecasify/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and apply snakecase function on the given keys.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 ```ts

--- a/parsers/sort-by/README.md
+++ b/parsers/sort-by/README.md
@@ -4,7 +4,7 @@
 
 Loop on all tokens and apply sort function on the given keys.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 

--- a/parsers/suffix-by/README.md
+++ b/parsers/suffix-by/README.md
@@ -4,7 +4,7 @@
 
 Allows to concatenate two strings.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 

--- a/parsers/svgo/README.md
+++ b/parsers/svgo/README.md
@@ -4,7 +4,7 @@
 
 SVG optimizer using [svgo](https://github.com/svg/svgo).
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 

--- a/parsers/to-css-custom-properties/README.md
+++ b/parsers/to-css-custom-properties/README.md
@@ -4,7 +4,7 @@
 
 Transform design tokens in CSS Custom Properties.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 

--- a/parsers/to-css-font-import/README.md
+++ b/parsers/to-css-font-import/README.md
@@ -4,7 +4,7 @@
 
 Create the code used to import font file.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface 
 

--- a/parsers/to-scss-mixin-text-style/README.md
+++ b/parsers/to-scss-mixin-text-style/README.md
@@ -4,7 +4,7 @@
 
 Create text styles formatted as SCSS mixins.
 
-Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli)
+Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers/cli](https://specifyapp.com/developers/cli).
 
 ## Interface
 


### PR DESCRIPTION
## What it does

Fix typos on many parsers including the new `filter` one. I also fixed the description of the `omit` parser.
