### PR TITLE
feat(to-tailwind): support pattern renaming for Tailwind theme keys

### DIFF
--- a/parsers/to-tailwind/README.md
+++ b/parsers/to-tailwind/README.md
@@ -31,6 +31,7 @@ interface parser {
       singleQuote: boolean;
       exportDefault: boolean;
     }>;
+    renameKeys: PartialRecord<TailwindType, string>;
   }>;
 }
 ```
@@ -49,6 +50,7 @@ interface parser {
 | `formatConfig.exportDefault`       | optional | `boolean`                                                         | `true`      |                                                                                |
 | `formatTokens.colorFormat.format`  | optional | `rgb` `prgb` `hex` `hex6` `hex3` `hex4` `hex8` `name` `hsl` `hsv` | `hex`       | The color format you want to apply to your potential color design token        |
 | `formatTokens.fontSizeFormat.unit` | optional | `px` `rem`                                                        | `none`      |                                                                                |
+| `renameKeys` | optional | `{ colors?: string, spacing?: string... }` [full list](https://github.com/Specifyapp/parsers/blob/master/parsers/to-tailwind/to-tailwind.type.ts#L16) | `none`      | Used to rename the generated tokens based on their Tailwind theme keys | 
 
 ## Types
 
@@ -160,7 +162,7 @@ const theme = {
 export default theme;
 ```
 
-## Complex usage - with specific config
+## Complex usage - with specific config for `colorFormat`
 
 ### Config
 
@@ -255,6 +257,69 @@ const extend = {
   },
   spacing: {
     'base-space-01': '4px',
+  },
+};
+
+module.exports = extend;
+```
+
+## Complex usage - with specific config for `renameKeys`
+
+### Config
+
+```json
+{
+  "name": "to-tailwind",
+  "options": {
+    "renameKeys": {
+      "colors": "custom-color-{{name}}",
+      "spacing": "custom-spacing-{{name}}"
+    },
+    "formatName": "kebabCase",
+    "formatConfig": {
+      "objectName": "extend",
+      "module": "commonjs"
+    }
+  }
+}
+```
+
+### Before/After
+
+#### Input
+
+```json
+[
+  {
+    "name": "primary",
+    "value": {
+      "a": 1,
+      "b": 255,
+      "g": 189,
+      "r": 198
+    },
+    "type": "color"
+  },
+  {
+    "name": "base-space-01",
+    "value": {
+      "unit": "px",
+      "measure": 4
+    },
+    "type": "measurement"
+  }
+]
+```
+
+#### Output
+
+```js
+const extend = {
+  colors: {
+    'custom-color-primary': '#C6BDFF',
+  },
+  spacing: {
+    'custom-spacing-base-space-01': '4px',
   },
 };
 

--- a/parsers/to-tailwind/to-tailwind.spec.ts
+++ b/parsers/to-tailwind/to-tailwind.spec.ts
@@ -15,6 +15,7 @@ import {
   ShadowToken,
   TextStyleToken,
 } from '../../types';
+import { getNameFormatterFunction } from './utils/getNameFormatterFunction';
 
 describe('To tailwind', () => {
   it('Should generate the colors object', async () => {
@@ -500,5 +501,290 @@ describe('To tailwind', () => {
     expect(result).toEqual(expect.stringMatching('export default extend'));
 
     return;
+  });
+
+  it('Should allow renaming of `border` tokens', async () => {
+    const tokens = seeds().tokens.filter(token => token.type === 'border') as Array<BorderToken>;
+    const borderWidthPrefix = 'border-width-';
+    const borderRadiusPrefix = 'border-radius-';
+    const borderColorPrefix = 'border-color-';
+    const borderOpacityPrefix = 'border-opacity-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          borderWidth: `${borderWidthPrefix}{{name}}`,
+          borderRadius: `${borderRadiusPrefix}{{name}}`,
+          borderColor: `${borderColorPrefix}{{name}}`,
+          borderOpacity: `${borderOpacityPrefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name, value }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${borderWidthPrefix}${transformedName}`));
+      expect(result).toEqual(expect.stringContaining(`${borderColorPrefix}${transformedName}`));
+
+      // only for tokens with radii values
+      if (value.radii) {
+        expect(result).toEqual(expect.stringContaining(`${borderRadiusPrefix}${transformedName}`));
+      }
+
+      // only for border color using alpha
+      if (value.color.value.a < 1) {
+        expect(result).toEqual(expect.stringContaining(`${borderOpacityPrefix}${transformedName}`));
+      }
+    });
+  });
+  it('Should allow renaming of `color` tokens', async () => {
+    const tokens = seeds().tokens.filter(token => token.type === 'color') as Array<ColorToken>;
+    const prefix = 'color-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          colors: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `depth` tokens', async () => {
+    const tokens = seeds().tokens.filter(token => token.type === 'depth') as Array<DepthToken>;
+    const prefix = 'depth-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          zIndex: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `duration` tokens', async () => {
+    const tokens = seeds().tokens.filter(
+      token => token.type === 'duration',
+    ) as Array<DurationToken>;
+    const prefix = 'duration-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          transitionDuration: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `gradient` tokens', async () => {
+    const tokens = seeds().tokens.filter(
+      token => token.type === 'gradient',
+    ) as Array<GradientToken>;
+    const prefix = 'gradient-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          backgroundImage: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `measurement` tokens', async () => {
+    const tokens = seeds().tokens.filter(
+      token => token.type === 'measurement',
+    ) as Array<MeasurementToken>;
+    const prefix = 'measurement-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          spacing: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `opacity` tokens', async () => {
+    const tokens = seeds().tokens.filter(token => token.type === 'opacity') as Array<OpacityToken>;
+    const prefix = 'opacity-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          opacity: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `shadow` tokens', async () => {
+    const tokens = seeds().tokens.filter(token => token.type === 'shadow') as Array<ShadowToken>;
+    const prefix = 'shadow-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          boxShadow: `${prefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+      expect(result).toEqual(expect.stringContaining(`${prefix}${transformedName}`));
+    });
+  });
+  it('Should allow renaming of `textStyle` tokens', async () => {
+    const tokens = seeds().tokens.filter(
+      token => token.type === 'textStyle',
+    ) as Array<TextStyleToken>;
+    const fontSizePrefix = 'text-style-font-size-';
+    const letterSpacingPrefix = 'text-style-letter-spacing-';
+    const lineHeightPrefix = 'text-style-line-height-';
+    const textColorPrefix = 'text-style-text-color-';
+    const textOpacityPrefix = 'text-style-text-opacity-';
+    const fontFamilyPrefix = 'text-style-font-family-';
+    const fontWeightPrefix = 'text-style-font-weight-';
+
+    const formatName = 'kebabCase';
+    const result = await toTailwind(
+      tokens,
+      {
+        renameKeys: {
+          fontSize: `${fontSizePrefix}{{name}}`,
+          letterSpacing: `${letterSpacingPrefix}{{name}}`,
+          lineHeight: `${lineHeightPrefix}{{name}}`,
+          textColor: `${textColorPrefix}{{name}}`,
+          textOpacity: `${textOpacityPrefix}{{name}}`,
+          fontFamily: `${fontFamilyPrefix}{{name}}`,
+          fontWeight: `${fontWeightPrefix}{{name}}`,
+        },
+        formatName,
+        formatConfig: {
+          module: 'es6',
+          exportDefault: true,
+          objectName: 'extend',
+        },
+      },
+      libs,
+    );
+
+    tokens.forEach(({ name, value }) => {
+      const transformedName = getNameFormatterFunction(formatName)(name);
+
+      expect(result).toEqual(expect.stringContaining(`${fontSizePrefix}${transformedName}`));
+      expect(result).toEqual(expect.stringContaining(`${lineHeightPrefix}${transformedName}`));
+      expect(result).toEqual(expect.stringContaining(`${fontFamilyPrefix}${transformedName}`));
+      expect(result).toEqual(expect.stringContaining(`${fontWeightPrefix}${transformedName}`));
+      if (value.letterSpacing) {
+        expect(result).toEqual(expect.stringContaining(`${letterSpacingPrefix}${transformedName}`));
+      }
+      if (value.color) {
+        expect(result).toEqual(expect.stringContaining(`${textColorPrefix}${transformedName}`));
+      }
+      if (value.color && value.color.value.a < 1) {
+        expect(result).toEqual(expect.stringContaining(`${textOpacityPrefix}${transformedName}`));
+      }
+    });
   });
 });

--- a/parsers/to-tailwind/to-tailwind.type.ts
+++ b/parsers/to-tailwind/to-tailwind.type.ts
@@ -105,3 +105,5 @@ export interface TailwindTokenClassInstance {
   transformedName: string;
   generate(options: OptionsType, spTokens: InputDataType): Partial<Record<TailwindType, any>>;
 }
+
+export type FormatName = 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';

--- a/parsers/to-tailwind/tokens/border.ts
+++ b/parsers/to-tailwind/tokens/border.ts
@@ -2,37 +2,44 @@ import { BorderToken } from '../../../types';
 import { BorderMapping } from '../to-tailwind.type';
 import tinycolor from 'tinycolor2';
 import { OptionsType } from '../to-tailwind.parser';
+import { Utils } from './index';
 
 export class Border extends BorderToken {
-  transformedName: string;
-  constructor(token: Partial<BorderToken>, transformedNameFn: Function) {
+  token: Partial<BorderToken>;
+  constructor(token: Partial<BorderToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformedNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
 
   generate(options: OptionsType): BorderMapping {
     const { width, radii, color } = this.value;
-    const result: BorderMapping = {
-      borderWidth: {
-        [this.transformedName]: `${width.value.measure}${width.value.unit}`,
-      },
-    };
+    const result = {} as BorderMapping;
+
+    if (width && width.value) {
+      const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.borderWidth);
+      result.borderWidth = {
+        [keyName]: `${width.value.measure}${width.value.unit}`,
+      };
+    }
 
     if (radii && radii.value) {
+      const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.borderRadius);
       result.borderRadius = {
-        [this.transformedName]: `${radii?.value.measure}${radii?.value.unit}`,
+        [keyName]: `${radii?.value.measure}${radii?.value.unit}`,
       };
     }
 
     if (color && color.value) {
+      const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.borderColor);
       result.borderColor = {
-        [this.transformedName]: tinycolor(color.value).toString(
+        [keyName]: tinycolor(color.value).toString(
           options?.formatTokens?.colorFormat?.format || 'hex',
         ),
       };
       if (color.value.a && color.value.a !== 1) {
+        const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.borderOpacity);
         result.borderOpacity = {
-          [this.transformedName]: `${color.value.a}`,
+          [keyName]: `${color.value.a}`,
         };
       }
     }

--- a/parsers/to-tailwind/tokens/color.ts
+++ b/parsers/to-tailwind/tokens/color.ts
@@ -2,17 +2,19 @@ import tinycolor from 'tinycolor2';
 import { ColorToken } from '../../../types';
 import { ColorMapping } from '../to-tailwind.type';
 import { OptionsType } from '../to-tailwind.parser';
+import { Utils } from './index';
 
 export class Color extends ColorToken {
-  transformedName: string;
+  token: Partial<ColorToken>;
   constructor(token: Partial<ColorToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
   generate(options: OptionsType): ColorMapping {
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.colors);
     return {
       colors: {
-        [this.transformedName]: tinycolor(this.value).toString(
+        [keyName]: tinycolor(this.value).toString(
           options?.formatTokens?.colorFormat?.format || 'hex',
         ),
       },

--- a/parsers/to-tailwind/tokens/depth.ts
+++ b/parsers/to-tailwind/tokens/depth.ts
@@ -1,18 +1,20 @@
 import { DepthToken } from '../../../types';
+import { OptionsType } from '../to-tailwind.parser';
 import { DepthMapping, TailwindMappingTypes } from '../to-tailwind.type';
 import { Utils } from './index';
 
 export class Depth extends DepthToken {
-  transformedName: string;
+  token: Partial<DepthToken>;
   constructor(token: Partial<DepthToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
 
-  generate(): DepthMapping {
+  generate(options: OptionsType): DepthMapping {
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.zIndex);
     return {
       zIndex: {
-        [this.transformedName]: `${this.value.depth}`,
+        [keyName]: `${this.value.depth}`,
       },
     };
   }

--- a/parsers/to-tailwind/tokens/duration.ts
+++ b/parsers/to-tailwind/tokens/duration.ts
@@ -1,17 +1,22 @@
 import { DurationToken } from '../../../types';
 import { Utils } from './index';
 import { DurationMapping, TailwindMappingTypes } from '../to-tailwind.type';
+import { OptionsType } from '../to-tailwind.parser';
 
 export class Duration extends DurationToken {
-  transformedName: string;
+  token: Partial<DurationToken>;
   constructor(token: Partial<DurationToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
-  generate(): DurationMapping {
+  generate(options: OptionsType): DurationMapping {
+    const keyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.transitionDuration,
+    );
     return {
       transitionDuration: {
-        [this.transformedName]: `${this.value.duration}${this.value.unit}`,
+        [keyName]: `${this.value.duration}${this.value.unit}`,
       },
     };
   }

--- a/parsers/to-tailwind/tokens/gradient.ts
+++ b/parsers/to-tailwind/tokens/gradient.ts
@@ -6,19 +6,22 @@ import {
   TailwindType,
 } from '../to-tailwind.type';
 import * as os from 'os';
+import { Utils } from './index';
+import { OptionsType } from '../to-tailwind.parser';
 
 export class Gradient extends GradientToken {
-  transformedName: string;
+  token: Partial<GradientToken>;
   static tailwindKeys: Array<TailwindType> = ['backgroundImage'];
   constructor(token: Partial<GradientToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
 
-  generate(): GradientMappingBeforeWrapper {
+  generate(options: OptionsType): GradientMappingBeforeWrapper {
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.backgroundImage);
     return {
       backgroundImage: {
-        [this.transformedName]: this.value.gradients
+        [keyName]: this.value.gradients
           .map(gradient => {
             return `linear-gradient(${gradient.angle}, ${gradient.colors
               .map(

--- a/parsers/to-tailwind/tokens/index.ts
+++ b/parsers/to-tailwind/tokens/index.ts
@@ -1,3 +1,6 @@
+import { Token } from '../../../types';
+import Template from '../../../libs/template';
+
 export * from './color';
 export * from './gradient';
 export * from './shadow';
@@ -17,5 +20,13 @@ export abstract class Utils {
     return Object.entries(obj)
       .sort(([, a], [, b]) => this.parseFloatIfString(a) - this.parseFloatIfString(b))
       .reduce((r, [k, v]) => ({ ...r, [k]: v }), {});
+  }
+
+  static getTemplatedTokenName(token: Partial<Token>, template: string | undefined) {
+    if (template) {
+      const templateInstance = new Template(template);
+      return templateInstance.render(token);
+    }
+    return token.name!;
   }
 }

--- a/parsers/to-tailwind/tokens/measurement.ts
+++ b/parsers/to-tailwind/tokens/measurement.ts
@@ -1,17 +1,19 @@
 import { MeasurementToken } from '../../../types';
 import { Utils } from './index';
 import { MeasurementMapping, TailwindMappingTypes } from '../to-tailwind.type';
+import { OptionsType } from '../to-tailwind.parser';
 
 export class Measurement extends MeasurementToken {
-  transformedName: string;
+  token: Partial<MeasurementToken>;
   constructor(token: Partial<MeasurementToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
-  generate(): MeasurementMapping {
+  generate(options: OptionsType): MeasurementMapping {
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.spacing);
     return {
       spacing: {
-        [this.transformedName]: `${this.value.measure}${this.value.unit}`,
+        [keyName]: `${this.value.measure}${this.value.unit}`,
       },
     };
   }

--- a/parsers/to-tailwind/tokens/opacity.ts
+++ b/parsers/to-tailwind/tokens/opacity.ts
@@ -1,19 +1,20 @@
 import { OpacityToken } from '../../../types';
 import { Utils } from './index';
 import { OpacityMapping } from '../to-tailwind.type';
+import { OptionsType } from '../to-tailwind.parser';
 
 export class Opacity extends OpacityToken {
-  transformedName: string;
-
+  token: Partial<OpacityToken>;
   constructor(token: Partial<OpacityToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
 
-  generate(): OpacityMapping {
+  generate(options: OptionsType): OpacityMapping {
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.opacity);
     return {
       opacity: {
-        [this.transformedName]: `${this.value.opacity / 100}`,
+        [keyName]: `${this.value.opacity / 100}`,
       },
     };
   }

--- a/parsers/to-tailwind/tokens/shadow.ts
+++ b/parsers/to-tailwind/tokens/shadow.ts
@@ -2,19 +2,21 @@ import { ShadowToken } from '../../../types';
 import { OptionsType } from '../to-tailwind.parser';
 import tinycolor from 'tinycolor2';
 import { ShadowMapping } from '../to-tailwind.type';
+import { Utils } from './index';
 
 export class Shadow extends ShadowToken {
-  transformedName: string;
+  token: Partial<ShadowToken>;
   constructor(token: Partial<ShadowToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
   generate(options: OptionsType): ShadowMapping {
     const colorFormat = options?.formatTokens?.colorFormat?.format ?? 'hex';
+    const keyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.boxShadow);
 
     return {
       boxShadow: {
-        [this.transformedName]: this.value
+        [keyName]: this.value
           .reduce<Array<string>>((acc, shadow) => {
             const { color, offsetX, offsetY, blur, isInner, spread } = shadow;
             const x = `${offsetX.value.measure}${offsetX.value.unit}`;

--- a/parsers/to-tailwind/tokens/textStyle.ts
+++ b/parsers/to-tailwind/tokens/textStyle.ts
@@ -6,10 +6,10 @@ import { FormatTokenType, OptionsType } from '../to-tailwind.parser';
 import tinycolor from 'tinycolor2';
 
 export class TextStyle extends TextStyleToken {
-  transformedName: string;
+  token: Partial<TextStyleToken>;
   constructor(token: Partial<TextStyleToken>, transformNameFn: Function) {
     super(token);
-    this.transformedName = transformNameFn(token.name);
+    this.token = { ...token, name: transformNameFn(token.name) };
   }
 
   private getFontWeight() {
@@ -49,27 +49,52 @@ export class TextStyle extends TextStyleToken {
   generate(options: OptionsType): TextStyleMapping {
     const result: TextStyleMapping = {};
 
+    const fontSizeKeyName = Utils.getTemplatedTokenName(this.token, options?.renameKeys?.fontSize);
     result.fontSize = {
-      [this.transformedName]: this.getFontSize(options?.formatTokens?.fontSizeFormat),
+      [fontSizeKeyName]: this.getFontSize(options?.formatTokens?.fontSizeFormat),
     };
 
+    const letterSpacingKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.letterSpacing,
+    );
     const letterSpacing = this.getLetterSpacing();
-    if (letterSpacing) result.letterSpacing = { [this.transformedName]: letterSpacing };
+    if (letterSpacing) result.letterSpacing = { [letterSpacingKeyName]: letterSpacing };
 
+    const lineHeightKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.lineHeight,
+    );
     const lineHeight = this.getLineHeight();
-    result.lineHeight = { [this.transformedName]: lineHeight };
+    result.lineHeight = { [lineHeightKeyName]: lineHeight };
 
     const textColor = this.getColor(options?.formatTokens?.colorFormat?.format || 'hex');
-    if (textColor) result.textColor = { [this.transformedName]: textColor };
+    const textColorKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.textColor,
+    );
+    if (textColor) result.textColor = { [textColorKeyName]: textColor };
 
     const textOpacity = this.getOpacity();
-    if (textOpacity) result.textOpacity = { [this.transformedName]: textOpacity };
+    const textOpacityKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.textOpacity,
+    );
+    if (textOpacity) result.textOpacity = { [textOpacityKeyName]: textOpacity };
 
     const fontFamily = this.getFontFamily();
-    result.fontFamily = { [this.transformedName]: [fontFamily] };
+    const fontFamilyKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.fontFamily,
+    );
+    result.fontFamily = { [fontFamilyKeyName]: [fontFamily] };
 
     const fontWeight = this.getFontWeight();
-    result.fontWeight = { [this.transformedName]: fontWeight };
+    const fontWeightKeyName = Utils.getTemplatedTokenName(
+      this.token,
+      options?.renameKeys?.fontWeight,
+    );
+    result.fontWeight = { [fontWeightKeyName]: fontWeight };
 
     return result;
   }

--- a/parsers/to-tailwind/utils/getNameFormatterFunction.ts
+++ b/parsers/to-tailwind/utils/getNameFormatterFunction.ts
@@ -1,0 +1,7 @@
+import * as _ from 'lodash';
+
+import { FormatName } from '../to-tailwind.type';
+
+export function getNameFormatterFunction(format: FormatName = 'camelCase') {
+  return _[format];
+}


### PR DESCRIPTION
## What it does

Adds a new `renameKeys` to the parser configuration. So that, each Tailwind theme key can get overwritten using a template pattern.

### Docs

#### Config

```json
{
  "name": "to-tailwind",
  "options": {
    "renameKeys": {
      "colors": "custom-color-{{name}}",
      "spacing": "custom-spacing-{{name}}"
    },
    "formatName": "kebabCase",
    "formatConfig": {
      "objectName": "extend",
      "module": "commonjs"
    }
  }
}
```

#### Before/After

**Input**

```json
[
  {
    "name": "primary",
    "value": {
      "a": 1,
      "b": 255,
      "g": 189,
      "r": 198
    },
    "type": "color"
  },
  {
    "name": "base-space-01",
    "value": {
      "unit": "px",
      "measure": 4
    },
    "type": "measurement"
  }
]
```

**Output**

```js
const extend = {
  colors: {
    'custom-color-primary': '#C6BDFF',
  },
  spacing: {
    'custom-spacing-base-space-01': '4px',
  },
};

module.exports = extend;
```

## Progress

- [x] Implement `renameKeys` in config
- [x] Cover with tests
- [x] Update docs

## Linear ticket
Resolves DEV-1096
