### PR TITLE
fix(to-react-native): use require-style imports on bitmaps

### DIFF
--- a/parsers/to-react-native/README.md
+++ b/parsers/to-react-native/README.md
@@ -180,12 +180,11 @@ string;
 #### Output
 
 ```js
-import assetAcmeLogo from '../src/assets/acmeLogo.png';
 import assetActivity from '../src/assets/activity.svg';
 
 const theme = {
   bitmap: {
-    acmeLogo: assetAcmeLogo,
+    acmeLogo: require('../src/assets/acmeLogo.png'),
   },
   vector: {
     activity: assetActivity,

--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -205,9 +205,7 @@ export default theme;
 `;
 
 exports[`To React Native Should use assetsFolderPath 1`] = `
-"import assetAcmeLogo from \\"path/acmeLogo.png\\";
-import assetPhotoExample from \\"path/photoExample.png\\";
-import assetActivity from \\"path/activity.svg\\";
+"import assetActivity from \\"path/activity.svg\\";
 import assetAirplay from \\"path/airplay.svg\\";
 import assetAlertCircle from \\"path/alertCircle.svg\\";
 import assetAlertOctagon from \\"path/alertOctagon.svg\\";
@@ -219,7 +217,10 @@ import assetUserMask from \\"path/userMask.svg\\";
 import assetUserMask from \\"path/userMask.pdf\\";
 
 const theme = {
-  bitmap: { acmeLogo: assetAcmeLogo, photoExample: assetPhotoExample },
+  bitmap: {
+    acmeLogo: require(\\"path/acmeLogo.png\\"),
+    photoExample: require(\\"path/photoExample.png\\"),
+  },
   vector: {
     activity: assetActivity,
     airplay: assetAirplay,

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -61,7 +61,7 @@ export default async function (
             }
             const fileName = template.render(token);
             const { theme, imports: tokenImports } = instance.toReactNative(options, fileName);
-            imports += tokenImports;
+            imports += tokenImports ?? '';
 
             return `'${token.name}': ${theme},`;
           }

--- a/parsers/to-react-native/tokens/bitmap.ts
+++ b/parsers/to-react-native/tokens/bitmap.ts
@@ -7,13 +7,12 @@ export class Bitmap extends BitmapToken {
     super(token);
   }
 
-  toReactNative(options: OptionsType, fileName: string): { theme: string; imports: string } {
+  toReactNative(options: OptionsType, fileName: string): { theme: string } {
     if (!options?.assetsFolderPath) {
       return {
         theme: JSON.stringify({
           uri: `'${this.value.url}'`,
         }),
-        imports: '',
       };
     }
 
@@ -22,11 +21,9 @@ export class Bitmap extends BitmapToken {
         ? options.assetsFolderPath
         : options.assetsFolderPath!.bitmap;
 
-    const symbol = `asset${this.name.charAt(0).toUpperCase()}${this.name.slice(1)}`;
     const fullPath = path.join(relPath || '', fileName);
     return {
-      theme: symbol,
-      imports: `import ${symbol} from '${fullPath}';\n`,
+      theme: `require('${fullPath}')`,
     };
   }
 }


### PR DESCRIPTION
Only require-style imports can resolve @2x and @3x bitmap variants. 

See https://reactnative.dev/docs/images#static-image-resources


