### PR TITLE
fix(to-style-dictionary): allow to generate all font formats described in the option fontFormat.

### DIFF
--- a/parsers/to-style-dictionary/to-style-dictionary.spec.ts
+++ b/parsers/to-style-dictionary/to-style-dictionary.spec.ts
@@ -1,7 +1,7 @@
 import toStyleDictionary from './to-style-dictionary.parser';
 import seeds from '../../tests/seeds';
 import libs from '../global-libs';
-import { Token } from '../../types';
+import { AllowedFormat, FontFormatList, Token } from '../../types';
 import * as TokensClass from './tokens';
 import {
   BaseStyleDictionaryTokensFormat,
@@ -560,6 +560,36 @@ describe('To Style Dictionary', () => {
             expectation.size.textIndent = { [firstLevelSplitedTokenName]: expect.any(Object) };
           }
           expect(result).toEqual(expectation);
+        });
+    });
+    it('Font', () => {
+      seeds()
+        .tokens.filter(({ type }) => type === 'font')
+        .map(font => {
+          const tokenClass: StyleDictionaryTokenClass = (<any>TokensClass)['Font'];
+          const [familyName, subFamilyName] = font.name.split('-');
+          const instance = new tokenClass(font, [familyName, subFamilyName]);
+          const expectedFormats: Array<AllowedFormat> = ['woff', 'woff2'];
+          const result = instance.generate({
+            formatTokens: {
+              fontFormat: expectedFormats,
+            },
+          });
+
+          expect(result).toEqual({
+            asset: {
+              font: {
+                [familyName]: {
+                  [subFamilyName]: expectedFormats.reduce<Record<string, object>>((acc, format) => {
+                    acc[format] = {
+                      value: `${font.name}.${format}`,
+                    };
+                    return acc;
+                  }, {}),
+                },
+              },
+            },
+          });
         });
     });
   });

--- a/parsers/to-style-dictionary/tokens/font.ts
+++ b/parsers/to-style-dictionary/tokens/font.ts
@@ -13,10 +13,10 @@ export class Font extends FontToken {
     return {
       asset: {
         font: (options?.formatTokens?.fontFormat ?? ['ttf']).reduce((acc, format) => {
-          const keys = [...this.keys, format];
+          const path = [...this.keys, format];
           _.setWith(
             acc,
-            keys,
+            path,
             {
               value: (options?.assetsBaseDirectory?.fonts ?? '') + `${this.name}.${format}`,
             },

--- a/parsers/to-style-dictionary/tokens/font.ts
+++ b/parsers/to-style-dictionary/tokens/font.ts
@@ -13,13 +13,12 @@ export class Font extends FontToken {
     return {
       asset: {
         font: (options?.formatTokens?.fontFormat ?? ['ttf']).reduce((acc, format) => {
+          const keys = [...this.keys, format];
           _.setWith(
             acc,
-            this.keys,
+            keys,
             {
-              [format]: {
-                value: (options?.assetsBaseDirectory?.fonts ?? '') + `${this.name}.${format}`,
-              },
+              value: (options?.assetsBaseDirectory?.fonts ?? '') + `${this.name}.${format}`,
             },
             Object,
           );


### PR DESCRIPTION
## What it does

- Fix bug that generates only one font format instead of those that have been defined in options
