### PR TITLE
improvement(to-style-dictionary): use join to allow trailing slash in…

### DIFF
--- a/parsers/to-style-dictionary/to-style-dictionary.spec.ts
+++ b/parsers/to-style-dictionary/to-style-dictionary.spec.ts
@@ -296,6 +296,36 @@ describe('To Style Dictionary', () => {
     });
   });
 
+  it('Should be able to extract Font token type with assetsBaseDirectory without trailing slash', async () => {
+    const result = await toStyleDictionary(
+      seeds().tokens.filter(({ type }) => type === 'font') as Array<Token>,
+      { splitBy: '/', assetsBaseDirectory: { fonts: 'fonts' } },
+      libs,
+    );
+
+    expect(Array.isArray(result)).toEqual(true);
+    expect(result.length).toEqual(1); // Time token only creates base
+    const file = result[0];
+    expect(typeof file.name).toEqual('string');
+    expect(file.name).toEqual('asset/font.json');
+    expect(typeof file.value.content).toEqual('string');
+    const content = JSON.parse(file.value.content!) as Record<string, any>;
+    expect(Object.keys(content)[0]).toEqual('asset');
+    expect(Object.keys(content.asset)[0]).toEqual('font');
+    Object.values(content).forEach(property => {
+      Object.values(property).forEach(nestedProperty => {
+        Object.values(nestedProperty as Record<string, Record<string, { value: string }>>).forEach(
+          format => {
+            Object.values(format).forEach(value => {
+              expect(value.value.includes('fonts/')).toBeTruthy();
+              expect(value.value).toEqual(expect.any(String));
+            });
+          },
+        );
+      });
+    });
+  });
+
   it('Should be able to extract Bitmap token type', async () => {
     const result = await toStyleDictionary(
       seeds().tokens.filter(({ type }) => type === 'bitmap') as Array<Token>,
@@ -341,6 +371,29 @@ describe('To Style Dictionary', () => {
     });
   });
 
+  it('Should be able to extract Bitmap token type with assetsBaseDirectory without trailing slash', async () => {
+    const result = await toStyleDictionary(
+      seeds().tokens.filter(({ type }) => type === 'bitmap') as Array<Token>,
+      { splitBy: '/', assetsBaseDirectory: { images: 'images' } },
+      libs,
+    );
+    expect(Array.isArray(result)).toEqual(true);
+    expect(result.length).toEqual(1); // Time token only creates base
+    const file = result[0];
+    expect(typeof file.name).toEqual('string');
+    expect(file.name).toEqual('asset/image.json');
+    expect(typeof file.value.content).toEqual('string');
+    const content = JSON.parse(file.value.content!) as Record<string, any>;
+    expect(Object.keys(content)[0]).toEqual('asset');
+    expect(Object.keys(content.asset)[0]).toEqual('image');
+    Object.values(content.asset).forEach(property => {
+      Object.values(property as Record<string, { value: string }>).forEach(nestedProperty => {
+        expect(nestedProperty.value.includes('images/')).toBeTruthy();
+        expect(nestedProperty.value).toEqual(expect.any(String));
+      });
+    });
+  });
+
   it('Should be able to extract Vector token type', async () => {
     const result = await toStyleDictionary(
       seeds().tokens.filter(({ type }) => type === 'vector') as Array<Token>,
@@ -367,6 +420,29 @@ describe('To Style Dictionary', () => {
     const result = await toStyleDictionary(
       seeds().tokens.filter(({ type }) => type === 'vector') as Array<Token>,
       { splitBy: '/', assetsBaseDirectory: { icons: 'icons/' } },
+      libs,
+    );
+    expect(Array.isArray(result)).toEqual(true);
+    expect(result.length).toEqual(1); // Time token only creates base
+    const file = result[0];
+    expect(typeof file.name).toEqual('string');
+    expect(file.name).toEqual('asset/icon.json');
+    expect(typeof file.value.content).toEqual('string');
+    const content = JSON.parse(file.value.content!) as Record<string, any>;
+    expect(Object.keys(content)[0]).toEqual('asset');
+    expect(Object.keys(content.asset)[0]).toEqual('icon');
+    Object.values(content.asset).forEach(property => {
+      Object.values(property as Record<string, { value: string }>).forEach(nestedProperty => {
+        expect(nestedProperty.value.includes('icons/')).toBeTruthy();
+        expect(nestedProperty.value).toEqual(expect.any(String));
+      });
+    });
+  });
+
+  it('Should be able to extract Vector token type with assetsBaseDirectory without trailing slash', async () => {
+    const result = await toStyleDictionary(
+      seeds().tokens.filter(({ type }) => type === 'vector') as Array<Token>,
+      { splitBy: '/', assetsBaseDirectory: { icons: 'icons' } },
       libs,
     );
     expect(Array.isArray(result)).toEqual(true);

--- a/parsers/to-style-dictionary/tokens/bitmap.ts
+++ b/parsers/to-style-dictionary/tokens/bitmap.ts
@@ -1,3 +1,4 @@
+import Path from 'path';
 import * as _ from 'lodash';
 import { BitmapToken } from '../../../types';
 import { OptionsType } from '../to-style-dictionary.parser';
@@ -14,9 +15,10 @@ export class Bitmap extends BitmapToken {
       {},
       this.keys,
       {
-        value:
-          (options?.assetsBaseDirectory?.images ?? '') +
+        value: Path.join(
+          options?.assetsBaseDirectory?.images ?? '',
           `${this.name}@${this.value.dimension ?? 1}.${this.value.format}`,
+        ),
       },
       Object,
     );

--- a/parsers/to-style-dictionary/tokens/font.ts
+++ b/parsers/to-style-dictionary/tokens/font.ts
@@ -1,3 +1,4 @@
+import Path from 'path';
 import * as _ from 'lodash';
 import { FontToken } from '../../../types';
 import { OptionsType } from '../to-style-dictionary.parser';
@@ -18,7 +19,7 @@ export class Font extends FontToken {
             acc,
             path,
             {
-              value: (options?.assetsBaseDirectory?.fonts ?? '') + `${this.name}.${format}`,
+              value: Path.join(options?.assetsBaseDirectory?.fonts ?? '', `${this.name}.${format}`),
             },
             Object,
           );

--- a/parsers/to-style-dictionary/tokens/vector.ts
+++ b/parsers/to-style-dictionary/tokens/vector.ts
@@ -1,3 +1,4 @@
+import Path from 'path';
 import * as _ from 'lodash';
 import { VectorToken } from '../../../types';
 import { OptionsType } from '../to-style-dictionary.parser';
@@ -14,7 +15,10 @@ export class Vector extends VectorToken {
       {},
       this.keys,
       {
-        value: (options?.assetsBaseDirectory?.icons ?? '') + `${this.name}.${this.value.format}`,
+        value: Path.join(
+          options?.assetsBaseDirectory?.icons ?? '',
+          `${this.name}.${this.value.format}`,
+        ),
       },
       Object,
     );


### PR DESCRIPTION
… assets path options

## What it does

- Allow usage of trailing slash in `assetsBaseDirectory` options.
