### PR TITLE
fix(to-react-native): make assets import for vector and bitmap relative

### DIFF
--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -205,21 +205,21 @@ export default theme;
 `;
 
 exports[`To React Native Should use assetsFolderPath 1`] = `
-"import assetActivity from \\"path/activity.svg\\";
-import assetAirplay from \\"path/airplay.svg\\";
-import assetAlertCircle from \\"path/alertCircle.svg\\";
-import assetAlertOctagon from \\"path/alertOctagon.svg\\";
-import assetAlertTriangle from \\"path/alertTriangle.pdf\\";
-import assetAlertTriangle from \\"path/alertTriangle.svg\\";
-import assetAlignCenter from \\"path/alignCenter.svg\\";
-import assetAlignCenter from \\"path/alignCenter.pdf\\";
-import assetUserMask from \\"path/userMask.svg\\";
-import assetUserMask from \\"path/userMask.pdf\\";
+"import assetActivity from \\"./path/activity.svg\\";
+import assetAirplay from \\"./path/airplay.svg\\";
+import assetAlertCircle from \\"./path/alertCircle.svg\\";
+import assetAlertOctagon from \\"./path/alertOctagon.svg\\";
+import assetAlertTriangle from \\"./path/alertTriangle.pdf\\";
+import assetAlertTriangle from \\"./path/alertTriangle.svg\\";
+import assetAlignCenter from \\"./path/alignCenter.svg\\";
+import assetAlignCenter from \\"./path/alignCenter.pdf\\";
+import assetUserMask from \\"./path/userMask.svg\\";
+import assetUserMask from \\"./path/userMask.pdf\\";
 
 const theme = {
   bitmap: {
-    acmeLogo: require(\\"path/acmeLogo.png\\"),
-    photoExample: require(\\"path/photoExample.png\\"),
+    acmeLogo: require(\\"./path/acmeLogo.png\\"),
+    photoExample: require(\\"./path/photoExample.png\\"),
   },
   vector: {
     activity: assetActivity,

--- a/parsers/to-react-native/tokens/bitmap.ts
+++ b/parsers/to-react-native/tokens/bitmap.ts
@@ -23,7 +23,7 @@ export class Bitmap extends BitmapToken {
 
     const fullPath = path.join(relPath || '', fileName);
     return {
-      theme: `require('${fullPath}')`,
+      theme: `require('./${fullPath}')`,
     };
   }
 }

--- a/parsers/to-react-native/tokens/vector.ts
+++ b/parsers/to-react-native/tokens/vector.ts
@@ -26,7 +26,7 @@ export class Vector extends VectorToken {
     const fullPath = path.join(relPath || '', fileName);
     return {
       theme: symbol,
-      imports: `import ${symbol} from '${fullPath}';\n`,
+      imports: `import ${symbol} from './${fullPath}';\n`,
     };
   }
 }


### PR DESCRIPTION
## What it does

- Make assets import for vector and bitmap relative.

FIx #136 