### PR TITLE
fix(to-react-native): don't fallback to black if no text color is defined

### DIFF
--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -104,7 +104,6 @@ exports[`To React Native Should generate the theme object 1`] = `
       fontSize: 14,
       lineHeight: 20,
       fontFamily: \\"Roboto-Regular\\",
-      color: \\"rgb(0, 0, 0)\\",
     },
     title: {
       fontWeight: \\"600\\",
@@ -295,7 +294,6 @@ const theme = {
       fontSize: 14,
       lineHeight: 20,
       fontFamily: \\"Roboto-Regular\\",
-      color: \\"rgb(0, 0, 0)\\",
     },
     title: {
       fontWeight: \\"600\\",

--- a/parsers/to-react-native/tokens/textStyle.ts
+++ b/parsers/to-react-native/tokens/textStyle.ts
@@ -20,7 +20,7 @@ export class TextStyle extends TextStyleToken {
       fontSize,
       lineHeight,
       fontFamily: fontPostScriptName,
-      color: tinycolor(color).toString(colorFormat),
+      color: color ? tinycolor(color).toString(colorFormat) : undefined,
       letterSpacing,
     };
     return JSON.stringify(fontObject);


### PR DESCRIPTION

## Expected behaviour
If a `textStyle` token has no color, the color should be omitted from the react native theme as well. 

## Actual behaviour
The color defaulted to `rgb(0, 0, 0)`, which is not desired

