### PR TITLE
feat(to-react-native)!: do not camelcase file names by default

### DIFF
--- a/parsers/to-react-native/README.md
+++ b/parsers/to-react-native/README.md
@@ -1,6 +1,7 @@
 # To React Native
 
 ## Description
+
 This parser helps you transform design tokens to a JavaScript `theme` object compatible with [React Native](https://reactnative.dev/).
 
 Learn more about how to configure Specify in the API documentation: [https://specifyapp.com/developers](https://specifyapp.com/developers).
@@ -29,6 +30,7 @@ interface parser {
       tabWidth: number;
       useTabs: boolean;
     }>;
+    formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
   }>;
 }
 ```
@@ -37,17 +39,18 @@ interface parser {
 
 ### Options
 
-| Parameter                    | Required | Type                                                                       | Default     | Description                                                                                                           |
-| ---------------------------- | -------- | -------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
-| `colorFormat`                | optional | `rgb`, `prgb`, `hex`, `hex6`, `hex3`, `hex4`, `hex8`, `name`, `hsl`, `hsv` | `rgb`       | The format of all colors (gradients, borders, textStyles etc.)                                                        |
-| `objectName`                 | optional | `string`                                                                   | `'theme'`   | The name of the JS object containing the theme (it will be the default export of the file).                           |
-| `assetsFolderPath`           | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the assets from, if not provided, the assets will be referenced by URL. |
-| `assetsFolderPath.vector`    | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the **vector** assets from.                                             |
-| `assetsFolderPath.bitmap`    | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the **bitmap** assets from.                                             |
-| `prettierConfig.endOfLine`   | optional | `auto, lf, crlf, cr`                                                       | `auto`      | [Prettier documentation](https://prettier.io/docs/en/options.html#end-of-line)                                        |
-| `prettierConfig.tabWidth`    | optional | `number`                                                                   | `2`         | [Prettier documentation](https://prettier.io/docs/en/options.html#tab-width)                                          |
-| `prettierConfig.useTabs`     | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#tabs)                                               |
-| `prettierConfig.singleQuote` | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)                                             |
+| Parameter                    | Required | Type                                                                       | Default     | Description                                                                                                                                                     |
+| ---------------------------- | -------- | -------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `colorFormat`                | optional | `rgb`, `prgb`, `hex`, `hex6`, `hex3`, `hex4`, `hex8`, `name`, `hsl`, `hsv` | `rgb`       | The format of all colors (gradients, borders, textStyles etc.)                                                                                                  |
+| `objectName`                 | optional | `string`                                                                   | `'theme'`   | The name of the JS object containing the theme (it will be the default export of the file).                                                                     |
+| `assetsFolderPath`           | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the assets from, if not provided, the assets will be referenced by URL.                                           |
+| `assetsFolderPath.vector`    | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the **vector** assets from.                                                                                       |
+| `assetsFolderPath.bitmap`    | optional | `string`                                                                   | `undefined` | The relative location of the folder to import the **bitmap** assets from.                                                                                       |
+| `prettierConfig.endOfLine`   | optional | `auto, lf, crlf, cr`                                                       | `auto`      | [Prettier documentation](https://prettier.io/docs/en/options.html#end-of-line)                                                                                  |
+| `prettierConfig.tabWidth`    | optional | `number`                                                                   | `2`         | [Prettier documentation](https://prettier.io/docs/en/options.html#tab-width)                                                                                    |
+| `prettierConfig.useTabs`     | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#tabs)                                                                                         |
+| `prettierConfig.singleQuote` | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)                                                                                       |
+| `formatFileName`             | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase` , `none`            | `camelCase` | Apply formatting to the file name in the import statements of vectors and bitmaps. Use this if you used transformations on the file names of downloaded assets. |
 
 ## Types
 
@@ -82,7 +85,8 @@ type output = string;
       "prettierConfig": {
         "tabWidth": 4,
         "singleQuote": true
-      }
+      },
+      "formatFileName": "none"
     }
   }
 ]
@@ -167,7 +171,7 @@ import assetActivity from '../src/assets/activity.svg';
 
 const theme = {
   bitmap: {
-    acmeLogo: require('../src/assets/acmeLogo.png'),
+    acmeLogo: require('../src/assets/acme-logo.png'),
   },
   vector: {
     activity: assetActivity,

--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -203,6 +203,886 @@ export default theme;
 "
 `;
 
+exports[`To React Native Should support different formatName options 1`] = `
+"import assetActivity from \\"./path/activity.svg\\";
+import assetAirplay from \\"./path/airplay.svg\\";
+import assetAlertCircle from \\"./path/alertCircle.svg\\";
+import assetAlertOctagon from \\"./path/alertOctagon.svg\\";
+import assetAlertTriangle from \\"./path/alertTriangle.pdf\\";
+import assetAlertTriangle from \\"./path/alertTriangle.svg\\";
+import assetAlignCenter from \\"./path/alignCenter.svg\\";
+import assetAlignCenter from \\"./path/alignCenter.pdf\\";
+import assetUserMask from \\"./path/userMask.svg\\";
+import assetUserMask from \\"./path/userMask.pdf\\";
+
+const theme = {
+  bitmap: {
+    acmeLogo: require(\\"./path/acmeLogo.png\\"),
+    photoExample: require(\\"./path/photoExample.png\\"),
+  },
+  vector: {
+    activity: assetActivity,
+    airplay: assetAirplay,
+    alertCircle: assetAlertCircle,
+    alertOctagon: assetAlertOctagon,
+    alertTriangle: assetAlertTriangle,
+    alertTriangle: assetAlertTriangle,
+    alignCenter: assetAlignCenter,
+    alignCenter: assetAlignCenter,
+    userMask: assetUserMask,
+    userMask: assetUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+};
+export default theme;
+"
+`;
+
+exports[`To React Native Should support different formatName options 2`] = `
+"import assetActivity from \\"./path/activity.svg\\";
+import assetAirplay from \\"./path/airplay.svg\\";
+import assetAlertCircle from \\"./path/alert-circle.svg\\";
+import assetAlertOctagon from \\"./path/alert-octagon.svg\\";
+import assetAlertTriangle from \\"./path/alert-triangle.pdf\\";
+import assetAlertTriangle from \\"./path/alert-triangle.svg\\";
+import assetAlignCenter from \\"./path/align-center.svg\\";
+import assetAlignCenter from \\"./path/align-center.pdf\\";
+import assetUserMask from \\"./path/user-mask.svg\\";
+import assetUserMask from \\"./path/user-mask.pdf\\";
+
+const theme = {
+  bitmap: {
+    acmeLogo: require(\\"./path/acme-logo.png\\"),
+    photoExample: require(\\"./path/photo-example.png\\"),
+  },
+  vector: {
+    activity: assetActivity,
+    airplay: assetAirplay,
+    alertCircle: assetAlertCircle,
+    alertOctagon: assetAlertOctagon,
+    alertTriangle: assetAlertTriangle,
+    alertTriangle: assetAlertTriangle,
+    alignCenter: assetAlignCenter,
+    alignCenter: assetAlignCenter,
+    userMask: assetUserMask,
+    userMask: assetUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+};
+export default theme;
+"
+`;
+
+exports[`To React Native Should support different formatName options 3`] = `
+"import assetActivity from \\"./path/activity.svg\\";
+import assetAirplay from \\"./path/airplay.svg\\";
+import assetAlertCircle from \\"./path/alert_circle.svg\\";
+import assetAlertOctagon from \\"./path/alert_octagon.svg\\";
+import assetAlertTriangle from \\"./path/alert_triangle.pdf\\";
+import assetAlertTriangle from \\"./path/alert_triangle.svg\\";
+import assetAlignCenter from \\"./path/align_center.svg\\";
+import assetAlignCenter from \\"./path/align_center.pdf\\";
+import assetUserMask from \\"./path/user_mask.svg\\";
+import assetUserMask from \\"./path/user_mask.pdf\\";
+
+const theme = {
+  bitmap: {
+    acmeLogo: require(\\"./path/acme_logo.png\\"),
+    photoExample: require(\\"./path/photo_example.png\\"),
+  },
+  vector: {
+    activity: assetActivity,
+    airplay: assetAirplay,
+    alertCircle: assetAlertCircle,
+    alertOctagon: assetAlertOctagon,
+    alertTriangle: assetAlertTriangle,
+    alertTriangle: assetAlertTriangle,
+    alignCenter: assetAlignCenter,
+    alignCenter: assetAlignCenter,
+    userMask: assetUserMask,
+    userMask: assetUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+};
+export default theme;
+"
+`;
+
+exports[`To React Native Should support different formatName options 4`] = `
+"import assetActivity from \\"./path/Activity.svg\\";
+import assetAirplay from \\"./path/Airplay.svg\\";
+import assetAlertCircle from \\"./path/AlertCircle.svg\\";
+import assetAlertOctagon from \\"./path/AlertOctagon.svg\\";
+import assetAlertTriangle from \\"./path/AlertTriangle.pdf\\";
+import assetAlertTriangle from \\"./path/AlertTriangle.svg\\";
+import assetAlignCenter from \\"./path/AlignCenter.svg\\";
+import assetAlignCenter from \\"./path/AlignCenter.pdf\\";
+import assetUserMask from \\"./path/UserMask.svg\\";
+import assetUserMask from \\"./path/UserMask.pdf\\";
+
+const theme = {
+  bitmap: {
+    acmeLogo: require(\\"./path/AcmeLogo.png\\"),
+    photoExample: require(\\"./path/PhotoExample.png\\"),
+  },
+  vector: {
+    activity: assetActivity,
+    airplay: assetAirplay,
+    alertCircle: assetAlertCircle,
+    alertOctagon: assetAlertOctagon,
+    alertTriangle: assetAlertTriangle,
+    alertTriangle: assetAlertTriangle,
+    alignCenter: assetAlignCenter,
+    alignCenter: assetAlignCenter,
+    userMask: assetUserMask,
+    userMask: assetUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+};
+export default theme;
+"
+`;
+
+exports[`To React Native Should support different formatName options 5`] = `
+"import assetActivity from \\"./path/activity.svg\\";
+import assetAirplay from \\"./path/airplay.svg\\";
+import assetAlertCircle from \\"./path/alert-circle.svg\\";
+import assetAlertOctagon from \\"./path/alert-octagon.svg\\";
+import assetAlertTriangle from \\"./path/alert-triangle.pdf\\";
+import assetAlertTriangle from \\"./path/alert-triangle.svg\\";
+import assetAlignCenter from \\"./path/align-center.svg\\";
+import assetAlignCenter from \\"./path/align-center.pdf\\";
+import assetUserMask from \\"./path/user-mask.svg\\";
+import assetUserMask from \\"./path/user-mask.pdf\\";
+
+const theme = {
+  bitmap: {
+    acmeLogo: require(\\"./path/acme-logo.png\\"),
+    photoExample: require(\\"./path/photo-example.png\\"),
+  },
+  vector: {
+    activity: assetActivity,
+    airplay: assetAirplay,
+    alertCircle: assetAlertCircle,
+    alertOctagon: assetAlertOctagon,
+    alertTriangle: assetAlertTriangle,
+    alertTriangle: assetAlertTriangle,
+    alignCenter: assetAlignCenter,
+    alignCenter: assetAlignCenter,
+    userMask: assetUserMask,
+    userMask: assetUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+};
+export default theme;
+"
+`;
+
 exports[`To React Native Should use assetsFolderPath 1`] = `
 "import assetActivity from \\"./path/activity.svg\\";
 import assetAirplay from \\"./path/airplay.svg\\";

--- a/parsers/to-react-native/to-react-native.spec.ts
+++ b/parsers/to-react-native/to-react-native.spec.ts
@@ -13,6 +13,19 @@ describe('To React Native', () => {
     const result = await toReactNative(tokens, { assetsFolderPath: 'path' }, libs);
     expect(result).toMatchSnapshot();
   });
+  it('Should support different formatName options', async () => {
+    (['camelCase', 'kebabCase', 'snakeCase', 'pascalCase', 'none'] as const).map(
+      async formatName => {
+        const tokens = seeds().tokens;
+        const result = await toReactNative(
+          tokens,
+          { assetsFolderPath: 'path', formatFileName: formatName },
+          libs,
+        );
+        expect(result).toMatchSnapshot();
+      },
+    );
+  });
   it('Should support different duration types', async () => {
     const tokens: InputDataType = [
       {

--- a/parsers/to-react-native/tokens/vector.ts
+++ b/parsers/to-react-native/tokens/vector.ts
@@ -1,6 +1,7 @@
 import { VectorToken } from '../../../types';
 import path from 'path';
 import { OptionsType } from '../to-react-native.parser';
+import { pascalCase } from 'lodash';
 
 export class Vector extends VectorToken {
   constructor(token: Partial<VectorToken>) {
@@ -22,7 +23,7 @@ export class Vector extends VectorToken {
         ? options.assetsFolderPath
         : options.assetsFolderPath!.vector;
 
-    const symbol = `asset${this.name.charAt(0).toUpperCase()}${this.name.slice(1)}`;
+    const symbol = `asset${pascalCase(this.name)}`;
     const fullPath = path.join(relPath || '', fileName);
     return {
       theme: symbol,


### PR DESCRIPTION
BREAKING CHANGE: previously, the `to-react-native` parser assumed you imported bitmaps and vectors with the `camelcasify` parser. This limits the flexibility of the way you name/structure assets. This change will remove default camelCasing from the `import` and `require` statements. You can always opt-in by prepending  the `to-react-native` parser with the `camelcasify` parser.

**Change in the default behaviour:**
```diff
  import assetActivity from "./path/activity.svg";
  import assetAirplay from "./path/airplay.svg";
- import assetAlertCircle from "./path/alertCircle.svg";
+ import assetAlertCircle from "./path/alert-circle.svg";
- import assetAlertOctagon from "./path/alertOctagon.svg";
+ import assetAlertOctagon from "./path/alert-octagon.svg";
- import assetAlertTriangle from "./path/alertTriangle.pdf";
+ import assetAlertTriangle from "./path/alert-triangle.pdf";
- import assetAlertTriangle from "./path/alertTriangle.svg";
+ import assetAlertTriangle from "./path/alert-triangle.svg";
- import assetAlignCenter from "./path/alignCenter.svg";
+ import assetAlignCenter from "./path/align-center.svg";
- import assetAlignCenter from "./path/alignCenter.pdf";
+ import assetAlignCenter from "./path/align-center.pdf";
- import assetUserMask from "./path/userMask.svg";
+ import assetUserMask from "./path/user-mask.svg";
- import assetUserMask from "./path/userMask.pdf";
+ import assetUserMask from "./path/user-mask.pdf";

  const theme = {
    bitmap: {
-     acmeLogo: require("./path/acmeLogo.png"),
+     acmeLogo: require("./path/acme-logo.png"),
-     photoExample: require("./path/photoExample.png"),
+     photoExample: require("./path/photo-example.png"),
    },
    vector: {
      activity: assetActivity,
      airplay: assetAirplay,
      alertCircle: assetAlertCircle,
```
