### PR TITLE
fix(filter): convert value to string before matching regex

### DIFF
--- a/parsers/filter/filter.parser.ts
+++ b/parsers/filter/filter.parser.ts
@@ -24,7 +24,7 @@ export default async function (
     const result: InputDataType = [];
     tokens.forEach(token => {
       const valueToCheck = _.get(token, options.key);
-      if (valueToCheck.match(reg)) {
+      if (!!valueToCheck && String(valueToCheck).match(reg)) {
         result.push(token);
       }
     });

--- a/parsers/filter/filter.spec.ts
+++ b/parsers/filter/filter.spec.ts
@@ -44,16 +44,6 @@ describe('Filter', () => {
     return;
   });
 
-  it('should throw error when key is wrong', async () => {
-    await expect(
-      filter(
-        seeds().tokens as Array<Token>,
-        { key: 'not exist', regex: { pattern: '', flags: 'g' } },
-        libs,
-      ),
-    ).rejects.toThrow(Error);
-  });
-
   it('Should return one element when RegEx is without flag', async () => {
     const result = await filter(
       seeds().tokens as Array<Token>,
@@ -86,6 +76,15 @@ describe('Filter', () => {
       { key: 'name', regex: 'Background' },
       libs,
     );
+    if (result instanceof Error) return fail(result);
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toEqual(true);
+    expect(result.length).toEqual(1);
+    return;
+  });
+
+  it('Should work on non-string values', async () => {
+    const result = await filter(seeds().tokens, { key: 'meta.dimension', regex: '2' }, libs);
     if (result instanceof Error) return fail(result);
     expect(result).toBeDefined();
     expect(Array.isArray(result)).toEqual(true);


### PR DESCRIPTION
## What it does

Currently you cannot filter on a non-string values: 
```
 Parser Error: Runtime Error at filter parser: valueToCheck.match is not 
    a function
```

This PR fixes that by converting to a string first.

## Additionnal informations

Example config: 
```ts
 {
    name: 'Only return @2x variants',
    path: 'bitmaps',
    filter: { types: ['bitmap'] },
    parsers: [
      {
        name: 'filter',
        options: {
          key: 'meta.dimension',
          regex: {
            pattern: '2',
          },
        },
      }
    ],
  };

```
## Linear ticket
Resolves [DEV-XXX]
