### PR TITLE
feat(to-react-native): add custom function capability for key parsing

### DIFF
--- a/parsers/to-react-native/README.md
+++ b/parsers/to-react-native/README.md
@@ -31,7 +31,8 @@ interface parser {
       useTabs: boolean;
     }>;
     formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
-    formatKeys: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+    formatKeys?: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+    formatKeyFunction?: (key: string) => string;
   }>;
 }
 ```
@@ -53,6 +54,7 @@ interface parser {
 | `prettierConfig.singleQuote` | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)                                                                                       |
 | `formatFileName`             | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase` , `none`            | `camelCase` | Apply formatting to the file name in the import statements of vectors and bitmaps. Use this if you used transformations on the file names of downloaded assets. |
 | `formatKeys`                 | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase`                     | `camelCase` | Apply formatting to each keyof the imported assets.                                                                                                             |
+| `formatKeyFunction`          | optional | `function`                                                                 | `undefined` | Runs the provided function for each key, allowing custom & programmatic formatting.                                                                             |
 
 ## Types
 

--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -189,6 +189,181 @@ export default theme;
 "
 `;
 
+exports[`To React Native Should support custom formatKeyFunction functions 1`] = `
+"import bitmapAcmeLogo from \\"./path/acmeLogo.png\\";
+import bitmapPhotoExample from \\"./path/photoExample.png\\";
+import vectorActivity from \\"./path/activity.svg\\";
+import vectorAirplay from \\"./path/airplay.svg\\";
+import vectorAlertCircle from \\"./path/alertCircle.svg\\";
+import vectorAlertOctagon from \\"./path/alertOctagon.svg\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.pdf\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.pdf\\";
+import vectorUserMask from \\"./path/userMask.svg\\";
+import vectorUserMask from \\"./path/userMask.pdf\\";
+
+const theme = {
+  bitmap: { ACMELOGO: bitmapAcmeLogo, PHOTOEXAMPLE: bitmapPhotoExample },
+  vector: {
+    ACTIVITY: vectorActivity,
+    AIRPLAY: vectorAirplay,
+    ALERTCIRCLE: vectorAlertCircle,
+    ALERTOCTAGON: vectorAlertOctagon,
+    ALERTTRIANGLE: vectorAlertTriangle,
+    ALERTTRIANGLE: vectorAlertTriangle,
+    ALIGNCENTER: vectorAlignCenter,
+    ALIGNCENTER: vectorAlignCenter,
+    USERMASK: vectorUserMask,
+    USERMASK: vectorUserMask,
+  },
+  depth: {
+    BACKGROUND: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    FOREGROUND: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    MIDDLE: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { BASE: 300, LONG: 700, SHORT: 100, VERYLONG: 3000 },
+  measurement: {
+    BASESPACE01: 4,
+    BASESPACE02: 8,
+    BASESPACE03: 12,
+    BASESPACE04: 16,
+    BASESPACE05: 32,
+    BASESPACE06: 48,
+    BASESPACE07: 64,
+    BASESPACE08: 80,
+    BASESPACE09: 96,
+    BASESPACE10: 112,
+  },
+  textStyle: {
+    BODY: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    BODYWITHOPACITY: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    CODE: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    LIST: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    TITLE: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    BORDERACCENT: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    BORDERACCENTWITHOPACITY: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    BORDERACCENTWITHOUTRADII: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    BORDERDASHED: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    COLORSACCENT: \\"rgb(87, 124, 254)\\",
+    COLORSBLACK: \\"rgb(30, 33, 43)\\",
+    COLORSGREEN: \\"rgb(88, 205, 82)\\",
+    COLORSGREY: \\"rgb(204, 213, 225)\\",
+    COLORSORANGE: \\"rgb(255, 142, 5)\\",
+    COLORSRED: \\"rgb(245, 72, 63)\\",
+    COLORSWHITE: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    FIRACODEMEDIUM: \\"FiraCode-Medium\\",
+    INTERMEDIUM: \\"Inter-Medium\\",
+    INTERSEMIBOLD: \\"Inter-SemiBold\\",
+    ROBOTOREGULAR: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    GRADIENTSCOLORED: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    GRADIENTSDARK: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    GRADIENTSNEUTRAL: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    GRADIENTSSAFARI: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { SUBTLE: 0.5, TRANSPARENT: 0.1, VISIBLE: 0.95 },
+};
+export default theme;
+"
+`;
+
 exports[`To React Native Should support different duration types 1`] = `
 "const theme = {
   duration: {

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -31,6 +31,7 @@ export type OptionsType =
       prettierConfig: prettier.Options;
       formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
       formatKeys: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+      formatKeyFunction: (key: string) => string;
     }>
   | undefined;
 
@@ -53,7 +54,9 @@ export default async function (
 
           if (!(<any>TokensClass)[tokenClassName]) return;
 
-          const formattedTokenName = _[options?.formatKeys ?? 'camelCase'](token.name);
+          const customParsedTokenName = options?.formatKeyFunction?.(token.name);
+          const formattedTokenName =
+            customParsedTokenName ?? _[options?.formatKeys ?? 'camelCase'](token.name);
 
           token.name =
             options?.formatFileName !== 'none'

--- a/parsers/to-react-native/to-react-native.spec.ts
+++ b/parsers/to-react-native/to-react-native.spec.ts
@@ -35,6 +35,23 @@ describe('To React Native', () => {
       expect(result).toMatchSnapshot();
     });
   });
+  it('Should support custom formatKeyFunction functions', async () => {
+    const formatKeyAsShouting = (key: string) => {
+      return key.replace(/[^A-z0-9]/g, '').toUpperCase();
+    };
+
+    const tokens = seeds().tokens;
+    const result = await toReactNative(
+      tokens,
+      {
+        assetsFolderPath: 'path',
+        formatKeyFunction: formatKeyAsShouting,
+      },
+      libs,
+    );
+
+    expect(result).toMatchSnapshot();
+  });
   it('Should support different duration types', async () => {
     const tokens: InputDataType = [
       {


### PR DESCRIPTION
This is the more radical version of #163, and would provide a lot of flexibility for customization, addresses my own suggestion in issue #164.

This would allow users to create their own key-parsing functions on the `to-react-native` parser, but may go against desired paradigms. 