### PR TITLE
feat(to-react-native): export style object as const

### DIFF
--- a/parsers/to-react-native/README.md
+++ b/parsers/to-react-native/README.md
@@ -32,7 +32,9 @@ interface parser {
     }>;
     formatFileName?: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
     formatKeys?: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
-    isTypescript?: boolean;
+    typescript?: {
+      castToConst?: boolean;
+    };
   }>;
 }
 ```
@@ -54,7 +56,7 @@ interface parser {
 | `prettierConfig.singleQuote` | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)                                                                                       |
 | `formatFileName`             | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase` , `none`            | `camelCase` | Apply formatting to the file name in the import statements of vectors and bitmaps. Use this if you used transformations on the file names of downloaded assets. |
 | `formatKeys`                 | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase`                     | `camelCase` | Apply formatting to each keyof the imported assets.                                                                                                             |
-| `isTypescript`               | optional | `boolean`                                                                  | `false`     | Adds `as const` to the end of the resulting exported object.                                                                                                    |
+| `typescript.castToConst`     | optional | `boolean`                                                                  | `false`     | Adds `as const` to the end of the resulting exported object.                                                                                                    |
 
 ## Types
 

--- a/parsers/to-react-native/README.md
+++ b/parsers/to-react-native/README.md
@@ -30,8 +30,9 @@ interface parser {
       tabWidth: number;
       useTabs: boolean;
     }>;
-    formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
-    formatKeys: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+    formatFileName?: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
+    formatKeys?: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+    isTypescript?: boolean;
   }>;
 }
 ```
@@ -53,6 +54,7 @@ interface parser {
 | `prettierConfig.singleQuote` | optional | `boolean`                                                                  | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)                                                                                       |
 | `formatFileName`             | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase` , `none`            | `camelCase` | Apply formatting to the file name in the import statements of vectors and bitmaps. Use this if you used transformations on the file names of downloaded assets. |
 | `formatKeys`                 | optional | `camelCase` , `kebabCase` , `snakeCase` , `pascalCase`                     | `camelCase` | Apply formatting to each keyof the imported assets.                                                                                                             |
+| `isTypescript`               | optional | `boolean`                                                                  | `false`     | Adds `as const` to the end of the resulting exported object.                                                                                                    |
 
 ## Types
 

--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -189,181 +189,6 @@ export default theme;
 "
 `;
 
-exports[`To React Native Should support TypeScript 1`] = `
-"import bitmapAcmeLogo from \\"./path/acmeLogo.png\\";
-import bitmapPhotoExample from \\"./path/photoExample.png\\";
-import vectorActivity from \\"./path/activity.svg\\";
-import vectorAirplay from \\"./path/airplay.svg\\";
-import vectorAlertCircle from \\"./path/alertCircle.svg\\";
-import vectorAlertOctagon from \\"./path/alertOctagon.svg\\";
-import vectorAlertTriangle from \\"./path/alertTriangle.pdf\\";
-import vectorAlertTriangle from \\"./path/alertTriangle.svg\\";
-import vectorAlignCenter from \\"./path/alignCenter.svg\\";
-import vectorAlignCenter from \\"./path/alignCenter.pdf\\";
-import vectorUserMask from \\"./path/userMask.svg\\";
-import vectorUserMask from \\"./path/userMask.pdf\\";
-
-const theme = {
-  bitmap: { acmeLogo: bitmapAcmeLogo, photoExample: bitmapPhotoExample },
-  vector: {
-    activity: vectorActivity,
-    airplay: vectorAirplay,
-    alertCircle: vectorAlertCircle,
-    alertOctagon: vectorAlertOctagon,
-    alertTriangle: vectorAlertTriangle,
-    alertTriangle: vectorAlertTriangle,
-    alignCenter: vectorAlignCenter,
-    alignCenter: vectorAlignCenter,
-    userMask: vectorUserMask,
-    userMask: vectorUserMask,
-  },
-  depth: {
-    background: {
-      elevation: 1,
-      shadowOpacity: 0.1815,
-      shadowRadius: 0.54,
-      shadowOffset: { width: 0.6, height: 0.6 },
-    },
-    foreground: {
-      elevation: 100,
-      shadowOpacity: 0.32999999999999996,
-      shadowRadius: 54,
-      shadowOffset: { width: 60, height: 60 },
-    },
-    middle: {
-      elevation: 50,
-      shadowOpacity: 0.255,
-      shadowRadius: 27,
-      shadowOffset: { width: 30, height: 30 },
-    },
-  },
-  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
-  measurement: {
-    baseSpace01: 4,
-    baseSpace02: 8,
-    baseSpace03: 12,
-    baseSpace04: 16,
-    baseSpace05: 32,
-    baseSpace06: 48,
-    baseSpace07: 64,
-    baseSpace08: 80,
-    baseSpace09: 96,
-    baseSpace10: 112,
-  },
-  textStyle: {
-    body: {
-      fontWeight: \\"500\\",
-      fontSize: 14,
-      lineHeight: 20,
-      fontFamily: \\"Inter-Medium\\",
-      color: \\"rgb(30, 33, 43)\\",
-      letterSpacing: 10,
-    },
-    bodyWithOpacity: {
-      fontWeight: \\"500\\",
-      fontSize: 14,
-      lineHeight: 20,
-      fontFamily: \\"Inter-Medium\\",
-      color: \\"rgba(30, 33, 43, 0.3)\\",
-      letterSpacing: 10,
-    },
-    code: {
-      fontWeight: \\"500\\",
-      fontSize: 13,
-      lineHeight: 20,
-      fontFamily: \\"FiraCode-Medium\\",
-      color: \\"rgb(255, 142, 5)\\",
-    },
-    list: {
-      fontWeight: \\"400\\",
-      fontSize: 14,
-      lineHeight: 20,
-      fontFamily: \\"Roboto-Regular\\",
-    },
-    title: {
-      fontWeight: \\"600\\",
-      fontSize: 32,
-      lineHeight: 40,
-      fontFamily: \\"Inter-SemiBold\\",
-      color: \\"rgb(30, 33, 43)\\",
-    },
-  },
-  border: {
-    borderAccent: {
-      borderWidth: 2,
-      borderStyle: \\"solid\\",
-      borderColor: \\"rgb(102, 80, 239)\\",
-      borderRadius: 16,
-    },
-    borderAccentWithOpacity: {
-      borderWidth: 2,
-      borderStyle: \\"solid\\",
-      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
-      borderRadius: 16,
-    },
-    borderAccentWithoutRadii: {
-      borderWidth: 2,
-      borderStyle: \\"solid\\",
-      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
-    },
-    borderDashed: {
-      borderWidth: 1,
-      borderStyle: \\"dashed\\",
-      borderColor: \\"rgb(30, 33, 43)\\",
-      borderRadius: 16,
-    },
-  },
-  color: {
-    colorsAccent: \\"rgb(87, 124, 254)\\",
-    colorsBlack: \\"rgb(30, 33, 43)\\",
-    colorsGreen: \\"rgb(88, 205, 82)\\",
-    colorsGrey: \\"rgb(204, 213, 225)\\",
-    colorsOrange: \\"rgb(255, 142, 5)\\",
-    colorsRed: \\"rgb(245, 72, 63)\\",
-    colorsWhite: \\"rgb(255, 255, 255)\\",
-  },
-  font: {
-    firaCodeMedium: \\"FiraCode-Medium\\",
-    interMedium: \\"Inter-Medium\\",
-    interSemiBold: \\"Inter-SemiBold\\",
-    robotoRegular: \\"Roboto-Regular\\",
-  },
-  gradient: {
-    gradientsColored: [
-      {
-        angle: 90,
-        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
-        locations: [0, 1],
-      },
-    ],
-    gradientsDark: [
-      {
-        angle: 90,
-        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
-        locations: [0, 1],
-      },
-    ],
-    gradientsNeutral: [
-      {
-        angle: 90,
-        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
-        locations: [0, 1],
-      },
-    ],
-    gradientsSafari: [
-      {
-        angle: 90,
-        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
-        locations: [0, 1],
-      },
-    ],
-  },
-  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
-} as const;
-export default theme;
-"
-`;
-
 exports[`To React Native Should support different duration types 1`] = `
 "const theme = {
   duration: {
@@ -1949,6 +1774,181 @@ const theme = {
   },
   opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
 };
+export default theme;
+"
+`;
+
+exports[`To React Native Should support the typescript.castToConst option 1`] = `
+"import bitmapAcmeLogo from \\"./path/acmeLogo.png\\";
+import bitmapPhotoExample from \\"./path/photoExample.png\\";
+import vectorActivity from \\"./path/activity.svg\\";
+import vectorAirplay from \\"./path/airplay.svg\\";
+import vectorAlertCircle from \\"./path/alertCircle.svg\\";
+import vectorAlertOctagon from \\"./path/alertOctagon.svg\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.pdf\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.pdf\\";
+import vectorUserMask from \\"./path/userMask.svg\\";
+import vectorUserMask from \\"./path/userMask.pdf\\";
+
+const theme = {
+  bitmap: { acmeLogo: bitmapAcmeLogo, photoExample: bitmapPhotoExample },
+  vector: {
+    activity: vectorActivity,
+    airplay: vectorAirplay,
+    alertCircle: vectorAlertCircle,
+    alertOctagon: vectorAlertOctagon,
+    alertTriangle: vectorAlertTriangle,
+    alertTriangle: vectorAlertTriangle,
+    alignCenter: vectorAlignCenter,
+    alignCenter: vectorAlignCenter,
+    userMask: vectorUserMask,
+    userMask: vectorUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+} as const;
 export default theme;
 "
 `;

--- a/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
+++ b/parsers/to-react-native/__snapshots__/to-react-native.spec.ts.snap
@@ -189,6 +189,181 @@ export default theme;
 "
 `;
 
+exports[`To React Native Should support TypeScript 1`] = `
+"import bitmapAcmeLogo from \\"./path/acmeLogo.png\\";
+import bitmapPhotoExample from \\"./path/photoExample.png\\";
+import vectorActivity from \\"./path/activity.svg\\";
+import vectorAirplay from \\"./path/airplay.svg\\";
+import vectorAlertCircle from \\"./path/alertCircle.svg\\";
+import vectorAlertOctagon from \\"./path/alertOctagon.svg\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.pdf\\";
+import vectorAlertTriangle from \\"./path/alertTriangle.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.svg\\";
+import vectorAlignCenter from \\"./path/alignCenter.pdf\\";
+import vectorUserMask from \\"./path/userMask.svg\\";
+import vectorUserMask from \\"./path/userMask.pdf\\";
+
+const theme = {
+  bitmap: { acmeLogo: bitmapAcmeLogo, photoExample: bitmapPhotoExample },
+  vector: {
+    activity: vectorActivity,
+    airplay: vectorAirplay,
+    alertCircle: vectorAlertCircle,
+    alertOctagon: vectorAlertOctagon,
+    alertTriangle: vectorAlertTriangle,
+    alertTriangle: vectorAlertTriangle,
+    alignCenter: vectorAlignCenter,
+    alignCenter: vectorAlignCenter,
+    userMask: vectorUserMask,
+    userMask: vectorUserMask,
+  },
+  depth: {
+    background: {
+      elevation: 1,
+      shadowOpacity: 0.1815,
+      shadowRadius: 0.54,
+      shadowOffset: { width: 0.6, height: 0.6 },
+    },
+    foreground: {
+      elevation: 100,
+      shadowOpacity: 0.32999999999999996,
+      shadowRadius: 54,
+      shadowOffset: { width: 60, height: 60 },
+    },
+    middle: {
+      elevation: 50,
+      shadowOpacity: 0.255,
+      shadowRadius: 27,
+      shadowOffset: { width: 30, height: 30 },
+    },
+  },
+  duration: { base: 300, long: 700, short: 100, veryLong: 3000 },
+  measurement: {
+    baseSpace01: 4,
+    baseSpace02: 8,
+    baseSpace03: 12,
+    baseSpace04: 16,
+    baseSpace05: 32,
+    baseSpace06: 48,
+    baseSpace07: 64,
+    baseSpace08: 80,
+    baseSpace09: 96,
+    baseSpace10: 112,
+  },
+  textStyle: {
+    body: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgb(30, 33, 43)\\",
+      letterSpacing: 10,
+    },
+    bodyWithOpacity: {
+      fontWeight: \\"500\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Inter-Medium\\",
+      color: \\"rgba(30, 33, 43, 0.3)\\",
+      letterSpacing: 10,
+    },
+    code: {
+      fontWeight: \\"500\\",
+      fontSize: 13,
+      lineHeight: 20,
+      fontFamily: \\"FiraCode-Medium\\",
+      color: \\"rgb(255, 142, 5)\\",
+    },
+    list: {
+      fontWeight: \\"400\\",
+      fontSize: 14,
+      lineHeight: 20,
+      fontFamily: \\"Roboto-Regular\\",
+    },
+    title: {
+      fontWeight: \\"600\\",
+      fontSize: 32,
+      lineHeight: 40,
+      fontFamily: \\"Inter-SemiBold\\",
+      color: \\"rgb(30, 33, 43)\\",
+    },
+  },
+  border: {
+    borderAccent: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgb(102, 80, 239)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithOpacity: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+      borderRadius: 16,
+    },
+    borderAccentWithoutRadii: {
+      borderWidth: 2,
+      borderStyle: \\"solid\\",
+      borderColor: \\"rgba(102, 80, 239, 0.5)\\",
+    },
+    borderDashed: {
+      borderWidth: 1,
+      borderStyle: \\"dashed\\",
+      borderColor: \\"rgb(30, 33, 43)\\",
+      borderRadius: 16,
+    },
+  },
+  color: {
+    colorsAccent: \\"rgb(87, 124, 254)\\",
+    colorsBlack: \\"rgb(30, 33, 43)\\",
+    colorsGreen: \\"rgb(88, 205, 82)\\",
+    colorsGrey: \\"rgb(204, 213, 225)\\",
+    colorsOrange: \\"rgb(255, 142, 5)\\",
+    colorsRed: \\"rgb(245, 72, 63)\\",
+    colorsWhite: \\"rgb(255, 255, 255)\\",
+  },
+  font: {
+    firaCodeMedium: \\"FiraCode-Medium\\",
+    interMedium: \\"Inter-Medium\\",
+    interSemiBold: \\"Inter-SemiBold\\",
+    robotoRegular: \\"Roboto-Regular\\",
+  },
+  gradient: {
+    gradientsColored: [
+      {
+        angle: 90,
+        colors: [\\"rgb(245, 72, 63)\\", \\"rgb(255, 142, 5)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsDark: [
+      {
+        angle: 90,
+        colors: [\\"rgb(30, 33, 43)\\", \\"rgb(204, 213, 225)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsNeutral: [
+      {
+        angle: 90,
+        colors: [\\"rgb(204, 213, 225)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+    gradientsSafari: [
+      {
+        angle: 90,
+        colors: [\\"rgb(255, 142, 5)\\", \\"rgb(255, 255, 255)\\"],
+        locations: [0, 1],
+      },
+    ],
+  },
+  opacity: { subtle: 0.5, transparent: 0.1, visible: 0.95 },
+} as const;
+export default theme;
+"
+`;
+
 exports[`To React Native Should support different duration types 1`] = `
 "const theme = {
   duration: {

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -31,7 +31,7 @@ export type OptionsType =
       prettierConfig: prettier.Options;
       formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
       formatKeys: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
-      isTypescript: boolean;
+      typescript: { castToConst?: boolean };
     }>
   | undefined;
 
@@ -84,18 +84,22 @@ export default async function (
       return result;
     }, '');
 
+    const isTypescript = typeof options?.typescript === 'object';
+
     return prettier.format(
       (() => {
         return [
           options?.header || '',
           imports,
-          `const ${objectName} = {${styles}}${options?.isTypescript ? ' as const' : ''};`,
+          `const ${objectName} = {${styles}}${
+            options?.typescript?.castToConst ? ' as const' : ''
+          };`,
           `export default ${objectName};`,
         ].join('\n');
       })(),
       {
         ...options?.prettierConfig,
-        parser: options?.isTypescript ? 'typescript' : 'babel',
+        parser: isTypescript ? 'typescript' : 'babel',
       },
     );
   } catch (err) {

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -88,7 +88,7 @@ export default async function (
         return [
           options?.header || '',
           imports,
-          `const ${objectName} = {${styles}};`,
+          `const ${objectName} = {${styles}} as const;`,
           `export default ${objectName};`,
         ].join('\n');
       })(),

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -84,8 +84,6 @@ export default async function (
       return result;
     }, '');
 
-    const isTypescript = typeof options?.typescript === 'object';
-
     return prettier.format(
       (() => {
         return [
@@ -99,7 +97,7 @@ export default async function (
       })(),
       {
         ...options?.prettierConfig,
-        parser: isTypescript ? 'typescript' : 'babel',
+        parser: 'babel-ts',
       },
     );
   } catch (err) {

--- a/parsers/to-react-native/to-react-native.parser.ts
+++ b/parsers/to-react-native/to-react-native.parser.ts
@@ -31,6 +31,7 @@ export type OptionsType =
       prettierConfig: prettier.Options;
       formatFileName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
       formatKeys: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+      isTypescript: boolean;
     }>
   | undefined;
 
@@ -88,13 +89,13 @@ export default async function (
         return [
           options?.header || '',
           imports,
-          `const ${objectName} = {${styles}} as const;`,
+          `const ${objectName} = {${styles}}${options?.isTypescript ? ' as const' : ''};`,
           `export default ${objectName};`,
         ].join('\n');
       })(),
       {
         ...options?.prettierConfig,
-        parser: 'babel',
+        parser: options?.isTypescript ? 'typescript' : 'babel',
       },
     );
   } catch (err) {

--- a/parsers/to-react-native/to-react-native.spec.ts
+++ b/parsers/to-react-native/to-react-native.spec.ts
@@ -7,6 +7,7 @@ describe('To React Native', () => {
     const tokens = seeds().tokens;
     const result = await toReactNative(tokens, undefined, libs);
     expect(result).toMatchSnapshot();
+    expect(result).toContain('};\nexport default theme;');
   });
   it('Should use assetsFolderPath', async () => {
     const tokens = seeds().tokens;
@@ -22,6 +23,7 @@ describe('To React Native', () => {
       { assetsFolderPath: 'path', typescript: { castToConst: true } },
       libs,
     );
+    expect(result).toContain('} as const;\nexport default theme;');
     expect(result).toMatchSnapshot();
   });
   it('Should support different formatName options', async () => {

--- a/parsers/to-react-native/to-react-native.spec.ts
+++ b/parsers/to-react-native/to-react-native.spec.ts
@@ -15,6 +15,15 @@ describe('To React Native', () => {
     expect(await toReactNative(tokens, { assetsFolderPath: '../path' }, libs)).toMatchSnapshot();
     expect(await toReactNative(tokens, { assetsFolderPath: '../path/' }, libs)).toMatchSnapshot();
   });
+  it('Should support the isTypescript option', async () => {
+    const tokens = seeds().tokens;
+    const result = await toReactNative(
+      tokens,
+      { assetsFolderPath: 'path', isTypescript: true },
+      libs,
+    );
+    expect(result).toMatchSnapshot();
+  });
   it('Should support different formatName options', async () => {
     (['camelCase', 'kebabCase', 'snakeCase', 'pascalCase', 'none'] as const).map(
       async formatName => {

--- a/parsers/to-react-native/to-react-native.spec.ts
+++ b/parsers/to-react-native/to-react-native.spec.ts
@@ -15,11 +15,11 @@ describe('To React Native', () => {
     expect(await toReactNative(tokens, { assetsFolderPath: '../path' }, libs)).toMatchSnapshot();
     expect(await toReactNative(tokens, { assetsFolderPath: '../path/' }, libs)).toMatchSnapshot();
   });
-  it('Should support the isTypescript option', async () => {
+  it('Should support the typescript.castToConst option', async () => {
     const tokens = seeds().tokens;
     const result = await toReactNative(
       tokens,
-      { assetsFolderPath: 'path', isTypescript: true },
+      { assetsFolderPath: 'path', typescript: { castToConst: true } },
       libs,
     );
     expect(result).toMatchSnapshot();


### PR DESCRIPTION
This pull request adds the `isTypescript` option to the `to-react-native` parser, which supplies `typescript` to prettier as the parser, as well as adds `as const` to the tail-end of the object in order to fix issues with union type incompatibilities in TypeScript projects (ie., `fontWeight`).