### PR TITLE
[Feature] Created `to-typescript-definition`  parser

### DIFF
--- a/parsers/to-typescript-definition/README.md
+++ b/parsers/to-typescript-definition/README.md
@@ -1,0 +1,136 @@
+# To Typescript Definition
+
+## Description
+
+Format design tokens to create a Typescript types definition file.
+
+This parser creates a Typescript types definition file with types names being tokens types, and the values of the types the name of the tokens.
+
+## Interface
+
+```ts
+interface parser {
+  name: 'to-typescript-definition';
+  options: Partial<{
+    formatName: 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
+    typesNamesMapping: Partial<{
+      font: string;
+      bitmap: string;
+      vector: string;
+      border: string;
+      color: string;
+      gradient: string;
+      duration: string;
+      measurement: string;
+      opacity: string;
+      shadow: string;
+      textStyle: string;
+      depth: string;
+    }>;
+  }>;
+}
+```
+
+### Options
+
+| Parameter                       | Required | Type                                                    | Default       | Description                                                         |
+| ------------------------------- | -------- | ------------------------------------------------------- | ------------- | ------------------------------------------------------------------- |
+| `formatName`                    | optional | `camelCase` `kebabCase` `snakeCase` `pascalCase` `none` | `kebabCase`   | The case transformation you want to apply to your design token name |
+| `typesNamesMapping.font`        | optional | `string`                                                | `font`        | How you want the type font to be named                              |
+| `typesNamesMapping.bitmap`      | optional | `string`                                                | `bitmap`      | How you want the type bitmap to be named                            |
+| `typesNamesMapping.vector`      | optional | `string`                                                | `vector`      | How you want the type vector to be named                            |
+| `typesNamesMapping.border`      | optional | `string`                                                | `border`      | How you want the type border to be named                            |
+| `typesNamesMapping.color`       | optional | `string`                                                | `color`       | How you want the type color to be named                             |
+| `typesNamesMapping.gradient`    | optional | `string`                                                | `gradient`    | How you want the type gradient to be named                          |
+| `typesNamesMapping.duration`    | optional | `string`                                                | `duration`    | How you want the type duration to be named                          |
+| `typesNamesMapping.measurement` | optional | `string`                                                | `measurement` | How you want the type measurement to be named                       |
+| `typesNamesMapping.opacity`     | optional | `string`                                                | `opacity`     | How you want the type opacity to be named                           |
+| `typesNamesMapping.shadow`      | optional | `string`                                                | `shadow`      | How you want the type shadow to be named                            |
+| `typesNamesMapping.textStyle`   | optional | `string`                                                | `textStyle`   | How you want the type textStyle to be named                         |
+| `typesNamesMapping.depth`       | optional | `string`                                                | `depth`       | How you want the type depth to be named                             |
+
+## Types
+
+ℹ️ **Please be aware that, depending on the order you use parsers, their input and output types have to match.**
+
+### Input
+
+Array of object with at least name and type:
+
+```ts
+type input = Array<{ name: string; type: string }>;
+```
+
+### Output
+
+String containing Typescript types exports
+
+```ts
+type output = string;
+```
+
+## Basic Usage
+
+### Config
+
+```jsonc
+"parsers": [
+  {
+    "name": "to-typescript-definition"
+  }
+  // …
+]
+```
+
+### Before/After
+
+#### Input
+
+```jsonc
+[
+  {
+    "name": "primary",
+    "value": {
+      "a": 1,
+      "b": 255,
+      "g": 189,
+      "r": 198
+    },
+    "type": "color"
+  },
+  {
+    "name": "secondary",
+    "value": {
+      "a": 1,
+      "b": 255,
+      "g": 189,
+      "r": 198
+    },
+    "type": "color"
+  },
+  {
+    "name": "base-space-01",
+    "value": {
+      "unit": "px",
+      "measure": 4
+    },
+    "type": "measurement"
+  },
+  {
+    "name": "base-space-02",
+    "value": {
+      "unit": "px",
+      "measure": 4
+    },
+    "type": "measurement"
+  }
+]
+```
+
+#### Output
+
+```ts
+type color = 'primary' | 'secondary';
+
+type measurement = 'base-space-01' | 'base-space-02';
+```

--- a/parsers/to-typescript-definition/README.md
+++ b/parsers/to-typescript-definition/README.md
@@ -130,7 +130,7 @@ type output = string;
 #### Output
 
 ```ts
-type color = 'primary' | 'secondary';
+export type color = 'primary' | 'secondary';
 
-type measurement = 'base-space-01' | 'base-space-02';
+export type measurement = 'base-space-01' | 'base-space-02';
 ```

--- a/parsers/to-typescript-definition/__snapshots__/to-typescript-definition.spec.ts.snap
+++ b/parsers/to-typescript-definition/__snapshots__/to-typescript-definition.spec.ts.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tokens to Typescript types definitions Should generate all the types with correct type name 1`] = `
+"export type bitmap = 'acme-logo' | 'photo-example' | 'photo-example' | 'photo-example'
+
+export type myVector = 'activity' | 'airplay' | 'alert-circle' | 'alert-octagon' | 'alert-triangle' | 'alert-triangle' | 'align-center' | 'align-center' | 'user-mask' | 'user-mask'
+
+export type depth = 'background' | 'foreground' | 'middle'
+
+export type duration = 'base' | 'long' | 'short' | 'very-long'
+
+export type measurement = 'base-space-01' | 'base-space-02' | 'base-space-03' | 'base-space-04' | 'base-space-05' | 'base-space-06' | 'base-space-07' | 'base-space-08' | 'base-space-09' | 'base-space-10'
+
+export type text_style = 'body' | 'body-with-opacity' | 'code' | 'list' | 'title'
+
+export type border = 'border-accent' | 'border-accent-with-opacity' | 'border-accent-without-radii' | 'border-dashed'
+
+export type helloColor = 'colors-accent' | 'colors-almost-black' | 'colors-black' | 'colors-green' | 'colors-grey' | 'colors-orange' | 'colors-pure-black' | 'colors-red' | 'colors-white'
+
+export type shadow = 'elevation-1' | 'elevation-2' | 'elevation-3'
+
+export type font = 'fira-code-medium' | 'inter-medium' | 'inter-semi-bold' | 'roboto-regular'
+
+export type gradient = 'gradients-colored' | 'gradients-dark' | 'gradients-neutral' | 'gradients-safari'
+
+export type opacity = 'subtle' | 'transparent' | 'visible'
+
+"
+`;
+
+exports[`Tokens to Typescript types definitions Should generate all the types with correct type name and formatting 1`] = `
+"export type bitmap = 'acme_logo' | 'photo_example' | 'photo_example' | 'photo_example'
+
+export type vector = 'activity' | 'airplay' | 'alert_circle' | 'alert_octagon' | 'alert_triangle' | 'alert_triangle' | 'align_center' | 'align_center' | 'user_mask' | 'user_mask'
+
+export type depth = 'background' | 'foreground' | 'middle'
+
+export type duration = 'base' | 'long' | 'short' | 'very_long'
+
+export type not = 'base_space_01' | 'base_space_02' | 'base_space_03' | 'base_space_04' | 'base_space_05' | 'base_space_06' | 'base_space_07' | 'base_space_08' | 'base_space_09' | 'base_space_10'
+
+export type textStyle = 'body' | 'body_with_opacity' | 'code' | 'list' | 'title'
+
+export type border = 'border_accent' | 'border_accent_with_opacity' | 'border_accent_without_radii' | 'border_dashed'
+
+export type another = 'colors_accent' | 'colors_almost_black' | 'colors_black' | 'colors_green' | 'colors_grey' | 'colors_orange' | 'colors_pure_black' | 'colors_red' | 'colors_white'
+
+export type why = 'elevation_1' | 'elevation_2' | 'elevation_3'
+
+export type font = 'fira_code_medium' | 'inter_medium' | 'inter_semi_bold' | 'roboto_regular'
+
+export type gradient = 'gradients_colored' | 'gradients_dark' | 'gradients_neutral' | 'gradients_safari'
+
+export type name = 'subtle' | 'transparent' | 'visible'
+
+"
+`;
+
+exports[`Tokens to Typescript types definitions Should generate all the types with default formatting 1`] = `
+"export type bitmap = 'acme-logo' | 'photo-example' | 'photo-example' | 'photo-example'
+
+export type vector = 'activity' | 'airplay' | 'alert-circle' | 'alert-octagon' | 'alert-triangle' | 'alert-triangle' | 'align-center' | 'align-center' | 'user-mask' | 'user-mask'
+
+export type depth = 'background' | 'foreground' | 'middle'
+
+export type duration = 'base' | 'long' | 'short' | 'very-long'
+
+export type measurement = 'base-space-01' | 'base-space-02' | 'base-space-03' | 'base-space-04' | 'base-space-05' | 'base-space-06' | 'base-space-07' | 'base-space-08' | 'base-space-09' | 'base-space-10'
+
+export type textStyle = 'body' | 'body-with-opacity' | 'code' | 'list' | 'title'
+
+export type border = 'border-accent' | 'border-accent-with-opacity' | 'border-accent-without-radii' | 'border-dashed'
+
+export type color = 'colors-accent' | 'colors-almost-black' | 'colors-black' | 'colors-green' | 'colors-grey' | 'colors-orange' | 'colors-pure-black' | 'colors-red' | 'colors-white'
+
+export type shadow = 'elevation-1' | 'elevation-2' | 'elevation-3'
+
+export type font = 'fira-code-medium' | 'inter-medium' | 'inter-semi-bold' | 'roboto-regular'
+
+export type gradient = 'gradients-colored' | 'gradients-dark' | 'gradients-neutral' | 'gradients-safari'
+
+export type opacity = 'subtle' | 'transparent' | 'visible'
+
+"
+`;

--- a/parsers/to-typescript-definition/to-typescript-definition.parser.ts
+++ b/parsers/to-typescript-definition/to-typescript-definition.parser.ts
@@ -1,0 +1,54 @@
+import * as _ from 'lodash';
+import { IToken, TokensType } from '../../types';
+import { LibsType } from '../global-libs';
+
+const DEFAULT_FORMAT = 'kebabCase';
+type format = 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase' | 'none';
+
+export type OutputDataType = string;
+export type InputDataType = Array<Pick<IToken, 'name' | 'type'> & Record<string, any>>;
+export type OptionsType =
+  | Partial<{
+      formatName: format;
+      typesNamesMapping: Partial<
+        {
+          [k in TokensType]: string;
+        }
+      >;
+    }>
+  | undefined;
+
+type groupedByType = Partial<{ [k in TokensType]: string[] }>;
+
+const applyFormat = (str: string, fn?: format) => {
+  if (fn && fn !== 'none') return _[fn](str);
+  return str.includes(' ') || str.includes('\n') || str.includes('/') ? JSON.stringify(str) : str;
+};
+
+export default async function toTypescriptDefinition(
+  tokens: InputDataType,
+  options: OptionsType,
+  { _ }: Pick<LibsType, '_'>,
+): Promise<OutputDataType> {
+  const grouped = tokens.reduce<groupedByType>((acc, current) => {
+    if (!acc[current.type])
+      return {
+        ...acc,
+        [current.type]: [current.name],
+      };
+    else {
+      return {
+        ...acc,
+        [current.type]: [...(acc[current.type] as string[]), current.name],
+      };
+    }
+  }, {});
+
+  return Object.entries(grouped).reduce<string>((acc, [key, values]) => {
+    const name = options?.typesNamesMapping?.[key as TokensType] ?? key;
+
+    return `${acc}export type ${name} = ${values
+      .map(v => `'${applyFormat(v, options?.formatName ?? DEFAULT_FORMAT)}'`)
+      .join(' | ')}\n\n`;
+  }, '');
+}

--- a/parsers/to-typescript-definition/to-typescript-definition.spec.ts
+++ b/parsers/to-typescript-definition/to-typescript-definition.spec.ts
@@ -1,0 +1,60 @@
+import seeds from '../../tests/seeds';
+import { IToken } from '../../types';
+import libs, { LibsType } from '../global-libs';
+import toTypescriptDefinition, {
+  InputDataType,
+  OptionsType,
+} from './to-typescript-definition.parser';
+
+const tokens = seeds().tokens;
+
+describe('Tokens to Typescript types definitions', () => {
+  it('Should generate all the types with default formatting', async () => {
+    const result = await toTypescriptDefinition(tokens as InputDataType, {}, libs as LibsType);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Should generate all the types with correct type name', async () => {
+    const result = await toTypescriptDefinition(
+      tokens as InputDataType,
+      {
+        typesNamesMapping: {
+          color: 'helloColor',
+          vector: 'myVector',
+          textStyle: 'text_style',
+        },
+      },
+      libs as LibsType,
+    );
+
+    expect(result.includes("export type helloColor = 'colors-accent'")).toBeTruthy();
+    expect(result.includes("export type myVector = 'activity'")).toBeTruthy();
+    expect(result.includes("export type text_style = 'body'")).toBeTruthy();
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Should generate all the types with correct type name and formatting', async () => {
+    const result = await toTypescriptDefinition(
+      tokens as InputDataType,
+      {
+        formatName: 'snakeCase',
+        typesNamesMapping: {
+          color: 'another',
+          opacity: 'name',
+          shadow: 'why',
+          measurement: 'not',
+        },
+      },
+      libs as LibsType,
+    );
+
+    expect(result.includes("export type another = 'colors_accent'")).toBeTruthy();
+    expect(result.includes("export type name = 'subtle'")).toBeTruthy();
+    expect(result.includes("export type why = 'elevation_1'")).toBeTruthy();
+    expect(result.includes("export type not = 'base_space_01'")).toBeTruthy();
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/parsers/to-typescript-definition/to-typescript-definition.spec.ts
+++ b/parsers/to-typescript-definition/to-typescript-definition.spec.ts
@@ -1,10 +1,6 @@
 import seeds from '../../tests/seeds';
-import { IToken } from '../../types';
 import libs, { LibsType } from '../global-libs';
-import toTypescriptDefinition, {
-  InputDataType,
-  OptionsType,
-} from './to-typescript-definition.parser';
+import toTypescriptDefinition, { InputDataType } from './to-typescript-definition.parser';
 
 const tokens = seeds().tokens;
 


### PR DESCRIPTION
# Description
This parser converts tokens into Typescript types. The token type is the type name, and the tokens values are the possible values of the type

Also for the `README`, I filled every possible cases in the `Option` part. I'm not sure if it's 100% relevant, but I don't think `typesNamesMapping.tokenType` would be really explicit