### PR TITLE
Add textStyle type to code sample

### DIFF
--- a/parsers/to-css-text-style/README.md
+++ b/parsers/to-css-text-style/README.md
@@ -122,6 +122,9 @@ type output = string;
 ### Config
 
 ```jsonc
+"filter": {
+  "types": ["textStyle"],
+},
 "parsers": [
   {
     "name": "to-css-text-style",


### PR DESCRIPTION
This adds the `textStyle` type filter to the code sample to make it more clear / in-line with the mention

>Please be aware that, depending on the order you use parsers, their input and output types have to match.