### PR TITLE
feat(to-tailwind): add in css variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,16 @@ To use our design tokens seed:
 1. Import it in your [parser].spec.ts using `import * as seeds from '../../seeds.json';`
 2. Use the `seeds.tokens` variable according to your needs.
 3. Launch `yarn test` to tests your parsers
+
+### Using your own tokens as seed data
+
+If you want to use your own tokens to test your parsers against, you can pull down your tokens in JSON format using the Specify CLI with the following configuration:
+
+```jsonc
+rules: [
+    {
+      "name": "design tokens",
+      "path": "tokens.json"`,
+    },
+  ],
+```

--- a/parsers/to-tailwind/README.md
+++ b/parsers/to-tailwind/README.md
@@ -32,6 +32,7 @@ interface parser {
       endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
       tabWidth: number;
       useTabs: boolean;
+      useVariables?: boolean;
       singleQuote: boolean;
       exportDefault: boolean;
     }>;
@@ -51,6 +52,7 @@ interface parser {
 | `formatConfig.endOfLine`           | optional | `auto` `lf` `crlf` `cr`                                                                                                                               | `auto`      | [Prettier documentation](https://prettier.io/docs/en/options.html#end-of-line) |
 | `formatConfig.tabWidth`            | optional | `number`                                                                                                                                              | `2`         | [Prettier documentation](https://prettier.io/docs/en/options.html#tab-width)   |
 | `formatConfig.useTabs`             | optional | `boolean`                                                                                                                                             | `true`      | [Prettier documentation](https://prettier.io/docs/en/options.html#tabs)        |
+| `formatConfig.useVariables`        | optional | `boolean`                                                                                                                                             | `false`     | Output utility class values as CSS variables                                   |
 | `formatConfig.singleQuote`         | optional | `boolean`                                                                                                                                             | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)      |
 | `formatConfig.exportDefault`       | optional | `boolean`                                                                                                                                             | `true`      |                                                                                |
 | `formatTokens.colorFormat.format`  | optional | `rgb` `prgb` `hex` `hex6` `hex3` `hex4` `hex8` `name` `hsl` `hsv` `raw`                                                                               | `hex`       | The color format you want to apply to your potential color design token        |
@@ -170,6 +172,76 @@ const theme = {
 
 export default theme;
 ```
+
+## Using CSS variables your utility class values
+
+The tailwind parser supports outputting CSS variables instead of hardcoded values in the theme. This enables functionality such as dark/light mode.
+
+### Prerequisites
+
+To enable CSS variables to work in the Tailwind output, you need to generate an associated CSS variables file. This can be achieved by using the [`to-css-custom-properties` parser](https://github.com/Specifyapp/parsers/blob/master/parsers/to-css-custom-properties/README.md). You must ensure that the formatName matches between both parser usages so that the referenced CSS variables exist.
+
+### Config
+
+```jsonc
+"parsers": [
+  {
+    "name": "to-tailwind",
+    "options": {
+      "formatName": "camelCase",
+      "formatConfig": {
+        "objectName": "extend",
+        "module": "commonjs",
+        "useVariables": true
+      }
+    }
+  }
+  // …
+]
+```
+
+### Before/After
+
+#### Input
+
+```jsonc
+{
+    "id": "5c819ba1-d0bc-43d8-91f6-952998eb345b",
+    "name": "Colors/Accent",
+    "value": {
+      "a": 1,
+      "b": 183,
+      "g": 133,
+      "r": 120
+    },
+    "type": "color",
+  },
+  {
+    "id": "a69b03e6-e5b0-4d74-a866-74b3161320f6",
+    "name": "Colors/AlmostBlack",
+    "value": {
+      "a": 1,
+      "b": 28,
+      "g": 28,
+      "r": 28
+    },
+    "type": "color",
+  },
+```
+
+#### After
+
+```js
+const extend = {
+  colors: {
+    colorsAccent: 'var(--colorsAccent)',
+    colorsAlmostBlack: 'var(--colorsAlmostBlack)',
+  },
+};
+
+module.exports = extend;
+```
+
 
 ## Complex usage - with specific config for `colorFormat`
 

--- a/parsers/to-tailwind/README.md
+++ b/parsers/to-tailwind/README.md
@@ -52,7 +52,7 @@ interface parser {
 | `formatConfig.endOfLine`           | optional | `auto` `lf` `crlf` `cr`                                                                                                                               | `auto`      | [Prettier documentation](https://prettier.io/docs/en/options.html#end-of-line) |
 | `formatConfig.tabWidth`            | optional | `number`                                                                                                                                              | `2`         | [Prettier documentation](https://prettier.io/docs/en/options.html#tab-width)   |
 | `formatConfig.useTabs`             | optional | `boolean`                                                                                                                                             | `true`      | [Prettier documentation](https://prettier.io/docs/en/options.html#tabs)        |
-| `formatConfig.useVariables`        | optional | `boolean`                                                                                                                                             | `false`     | Output utility class values as CSS variables                                   |
+| `formatConfig.useVariables`        | optional | `boolean`                                                                                                                                             | `false`     | Output utility class values as CSS variables. Requires CSS variables file using `to-css-custom-properties` parser                                   |
 | `formatConfig.singleQuote`         | optional | `boolean`                                                                                                                                             | `false`     | [Prettier documentation](https://prettier.io/docs/en/options.html#quotes)      |
 | `formatConfig.exportDefault`       | optional | `boolean`                                                                                                                                             | `true`      |                                                                                |
 | `formatTokens.colorFormat.format`  | optional | `rgb` `prgb` `hex` `hex6` `hex3` `hex4` `hex8` `name` `hsl` `hsv` `raw`                                                                               | `hex`       | The color format you want to apply to your potential color design token        |
@@ -173,13 +173,13 @@ const theme = {
 export default theme;
 ```
 
-## Using CSS variables your utility class values
+## Using CSS variables for utility class values (`useVariables`)
 
 The tailwind parser supports outputting CSS variables instead of hardcoded values in the theme. This enables functionality such as dark/light mode.
 
 ### Prerequisites
 
-To enable CSS variables to work in the Tailwind output, you need to generate an associated CSS variables file. This can be achieved by using the [`to-css-custom-properties` parser](https://github.com/Specifyapp/parsers/blob/master/parsers/to-css-custom-properties/README.md). You must ensure that the formatName matches between both parser usages so that the referenced CSS variables exist.
+To enable CSS variables to work in the Tailwind output, you need to generate an associated CSS variables file. This can be achieved by using the [`to-css-custom-properties`](https://github.com/Specifyapp/parsers/blob/master/parsers/to-css-custom-properties/README.md) parser. You must ensure that the formatName matches between both parser usages so that the referenced CSS variables exist.
 
 ### Config
 
@@ -227,6 +227,7 @@ To enable CSS variables to work in the Tailwind output, you need to generate an 
     },
     "type": "color",
   },
+}
 ```
 
 #### After
@@ -242,6 +243,20 @@ const extend = {
 module.exports = extend;
 ```
 
+#### Using a different format name - `kebabCase`
+
+The format name is used when generating the CSS variable reference so that it will match what you have in the CSS variables file. Setting formatName to `kebabCase` would result in the following output.
+
+```js
+const extend = {
+  colors: {
+    'colors-accent': 'var(--colors-accent)',
+    'colors-almost-black': 'var(--colors-almost-black)',
+  },
+};
+
+module.exports = extend;
+```
 
 ## Complex usage - with specific config for `colorFormat`
 

--- a/parsers/to-tailwind/to-tailwind.parser.ts
+++ b/parsers/to-tailwind/to-tailwind.parser.ts
@@ -18,6 +18,9 @@ export type FormatTokenType = Partial<{
   fontSizeFormat: {
     unit: 'px' | 'rem';
   };
+  valueFormat: {
+    useVariables?: boolean;
+  };
 }>;
 export type OptionsType =
   | Partial<{
@@ -31,6 +34,10 @@ export type OptionsType =
         useTabs: boolean;
         singleQuote: boolean;
         exportDefault: boolean;
+        /**
+         * Sets the value of the class as a CSS variable reference. You will need to generate a CSS variables file using the `to-css-custom-properties` parser.
+         */
+        useVariables: boolean;
       }>;
       renameKeys: PartialRecord<TailwindType, string>;
       splitBy?: string;
@@ -59,6 +66,7 @@ class ToTailwind {
     this.tokensGroupedByType = _.groupBy(tokens, 'type');
     this.styles = {};
   }
+
   exec() {
     const tokenTypes = Object.keys(this.tokensGroupedByType) as Array<TokensType>;
     this.styles = tokenTypes.reduce(
@@ -75,6 +83,7 @@ class ToTailwind {
     const tokenByType = this.tokensGroupedByType[tokenType].reduce((acc, token) => {
       const instance = new TokenHandler(token);
       const tailwindTokens = instance.generate(this.options, this.tokens);
+
       return deepmerge(acc, tailwindTokens);
     }, {});
 

--- a/parsers/to-tailwind/to-tailwind.parser.ts
+++ b/parsers/to-tailwind/to-tailwind.parser.ts
@@ -35,7 +35,7 @@ export type OptionsType =
         singleQuote: boolean;
         exportDefault: boolean;
         /**
-         * Sets the value of the class as a CSS variable reference. You will need to generate a CSS variables file using the `to-css-custom-properties` parser.
+         * Sets the value of the class as a CSS variable reference. An associated CSS variables file is required using the `to-css-custom-properties` parser.
          */
         useVariables: boolean;
       }>;

--- a/parsers/to-tailwind/to-tailwind.spec.ts
+++ b/parsers/to-tailwind/to-tailwind.spec.ts
@@ -57,8 +57,6 @@ describe('To tailwind', () => {
           libs,
         );
 
-        console.log(result)
-
         tokens.forEach(({ name }) => {
           const transformNameFn = getNameFormatterFunction(formatName);
           const formatted = transformNameFn(name);

--- a/parsers/to-tailwind/to-tailwind.type.ts
+++ b/parsers/to-tailwind/to-tailwind.type.ts
@@ -107,4 +107,5 @@ export interface TailwindTokenClassInstance {
   generate(options: OptionsType, spTokens: InputDataType): Partial<Record<TailwindType, any>>;
 }
 
-export type FormatName = 'camelCase' | 'kebabCase' | 'snakeCase' | 'pascalCase';
+export const formatNameArray = ['camelCase', 'kebabCase', 'snakeCase', 'pascalCase'] as const;
+export type FormatName = typeof formatNameArray[number];

--- a/parsers/to-tailwind/tokens/index.ts
+++ b/parsers/to-tailwind/tokens/index.ts
@@ -1,9 +1,11 @@
 import { Token } from '../../../types';
 import Template from '../../../libs/template';
 import * as _ from 'lodash';
+import { pascalCase } from 'lodash';
 import { getNameFormatterFunction } from '../utils/getNameFormatterFunction';
 import { TailwindType } from '../to-tailwind.type';
 import { OptionsType } from '../to-tailwind.parser';
+import { getClassNameAsCSSVariable } from '../utils/getClassNameAsCSSVariable';
 
 export * from './color';
 export * from './gradient';
@@ -34,14 +36,21 @@ export abstract class Utils {
     return token.name!;
   }
 
+  static getValue(key: string, value: unknown, options: OptionsType) {
+    if (options?.formatConfig?.useVariables) {
+      return getClassNameAsCSSVariable(String(key), options.formatName);
+    }
+
+    return value
+  }
+
   static go<T>(token: T, options: OptionsType, tailwindKey: TailwindType, value: unknown) {
     const keyName = this.getTemplatedTokenName(token, options?.renameKeys?.[tailwindKey]);
     const keys = [...(options?.splitBy ? keyName.split(new RegExp(options.splitBy)) : [keyName])];
-    return _.setWith(
-      {},
-      keys.map(k => getNameFormatterFunction(options?.formatName)(k)).join('.'),
-      value,
-      Object,
-    );
+
+    const key = keys.map(k => getNameFormatterFunction(options?.formatName)(k)).join('.');
+    const val = Utils.getValue(key, value, options);
+
+    return _.setWith({}, key, val, Object);
   }
 }

--- a/parsers/to-tailwind/utils/getClassNameAsCSSVariable.ts
+++ b/parsers/to-tailwind/utils/getClassNameAsCSSVariable.ts
@@ -1,0 +1,11 @@
+import * as _ from 'lodash';
+
+import { FormatName } from '../to-tailwind.type';
+import { getNameFormatterFunction } from './getNameFormatterFunction';
+
+export function getClassNameAsCSSVariable(str: string, format: FormatName = 'camelCase') {
+  const transformNameFn = getNameFormatterFunction(format);
+  const formatted = transformNameFn(str);
+
+  return `var(--${formatted.replace('/', '')})`
+}


### PR DESCRIPTION
This PR adds in support for outputting CSS variables as the utility class value in the Tailwind theme. This enables functionality such as dark/light mode to be possible and a big selling point of Design Tokens with a single tailwind theme but dynamic values for each key in the theme. This also empowers use cases such as whitelabelling of applications with the switchability of underlying styling but a consistent codebase.

- I have added some tests that checks for the correctly formatted `var()` for each token being in the output. I had to mock the lodash mixin as for some reason it wasn't working in Jest and no other tests in the repository were using the pascalCase formatting mixin so I didn't have any other examples to follow. The tests also ensure the formatted is correct for each type of formatName present in the parser.
- Updated README for the `to-tailwind` parser for information on how to setup variable usage.
- Updated the root README to include information on how to pull in the raw Specify tokens in JSON format as I couldn't find it documented anywhere.

Can certainly add additional tests if there are any suggestions on how to test it further. Look forward to some reviews. Thanks 😄 
