### PR TITLE
refactor(to-css-custom-properties): Replaced font name by fontPostScriptName

### DIFF
--- a/parsers/to-css-custom-properties/__snapshots__/to-css-custom-properties.spec.ts.snap
+++ b/parsers/to-css-custom-properties/__snapshots__/to-css-custom-properties.spec.ts.snap
@@ -45,33 +45,33 @@ exports[`To css Get tokens - apply parsers - all tokens 1`] = `
 
   /* TEXTSTYLE */
   --body-color: rgb(30, 33, 43);
-  --body-font-family: Inter;
+  --body-font-family: Inter-Medium;
   --body-font-weight: 500;
   --body-font-size: 14px;
   --body-letter-spacing: 10px;
   --body-line-height: 20px;
   --body-text-align: left;
   --body-with-opacity-color: rgba(30, 33, 43, 0.3);
-  --body-with-opacity-font-family: Inter;
+  --body-with-opacity-font-family: Inter-Medium;
   --body-with-opacity-font-weight: 500;
   --body-with-opacity-font-size: 14px;
   --body-with-opacity-letter-spacing: 10px;
   --body-with-opacity-line-height: 20px;
   --body-with-opacity-text-align: left;
   --code-color: rgb(255, 142, 5);
-  --code-font-family: Fira Code;
+  --code-font-family: FiraCode-Medium;
   --code-font-weight: 500;
   --code-font-size: 13px;
   --code-line-height: 20px;
   --code-text-align: left;
-  --list-font-family: Roboto;
+  --list-font-family: Roboto-Regular;
   --list-font-weight: 400;
   --list-font-size: 14px;
   --list-font-variant: small-caps;
   --list-line-height: 20px;
   --list-text-align: left;
   --title-color: rgb(30, 33, 43);
-  --title-font-family: Inter;
+  --title-font-family: Inter-SemiBold;
   --title-font-weight: 600;
   --title-font-size: 32px;
   --title-line-height: 40px;

--- a/parsers/to-css-custom-properties/to-css-custom-properties.spec.ts
+++ b/parsers/to-css-custom-properties/to-css-custom-properties.spec.ts
@@ -62,7 +62,7 @@ describe('To css', () => {
     expect(result).toBe(`:root {
   /* TEXTSTYLE */
   --body-color: rgb(30, 33, 43);
-  --body-font-family: Inter;
+  --body-font-family: Inter-Medium;
   --body-font-weight: 500;
   --body-font-style: italic;
   --body-font-size: 14px;

--- a/parsers/to-css-custom-properties/tokens/textStyle.ts
+++ b/parsers/to-css-custom-properties/tokens/textStyle.ts
@@ -18,7 +18,7 @@ export class TextStyle extends TextStyleToken {
             options?.formatTokens?.color || 'rgb',
           )};`
         : undefined,
-      `${BASE}-font-family: ${this.value.font.value.fontFamily};`,
+      `${BASE}-font-family: ${this.value.font.value.fontPostScriptName};`,
       `${BASE}-font-weight: ${this.value.font.value.fontWeight};`,
       !!this.value.font.value.isItalic ? `${BASE}-font-style: italic;` : undefined,
       `${BASE}-font-size: ${this.value.fontSize.value.measure}${this.value.fontSize.value.unit};`,


### PR DESCRIPTION
# Description
This PR updates the text-style font-family and replace it by `fontPostScriptName`